### PR TITLE
Fix: Element editor text issue solved

### DIFF
--- a/src/people/PeoplePage.tsx
+++ b/src/people/PeoplePage.tsx
@@ -12,7 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { AISearch } from "./components/AISearch";
 
 export const PeoplePage = memo(() => {
-  const [searchResults, setSearchResults] = React.useState(null);
+  const [searchResults, setSearchResults] = React.useState<PersonInterface[] | null>(null);
   const [selectedColumns, setSelectedColumns] = React.useState<string[]>(["photo", "displayName"]);
   const [isSearchPerformed, setIsSearchPerformed] = React.useState(false);
   const canEdit = UserHelper.checkAccess(Permissions.membershipApi.people.edit);
@@ -72,6 +72,11 @@ export const PeoplePage = memo(() => {
     if (!recentPeople.data) return [];
     return recentPeople.data.map((d: PersonInterface) => B1AdminPersonHelper.getExpandedPersonObject(d));
   }, [recentPeople.data]);
+
+  const resetSearchResults = useCallback(() => {
+    setSearchResults(expandedRecentPeople);
+    setIsSearchPerformed(false);
+  }, [expandedRecentPeople]);
 
   React.useEffect(() => {
     if (recentPeople.data && !isSearchPerformed) {
@@ -161,6 +166,7 @@ export const PeoplePage = memo(() => {
                 setSearchResults(people);
                 setIsSearchPerformed(true);
               }}
+              resetSearchResults={resetSearchResults}
               updatedFunction={refetch}
             />
             <AISearch
@@ -189,7 +195,13 @@ export const PeoplePage = memo(() => {
                 </Stack>
               </Box>
               <Box>
-                <PeopleSearchResults people={searchResults} columns={columns} selectedColumns={selectedColumns} updateSearchResults={(people) => setSearchResults(people)} updatedFunction={refetch} />
+                <PeopleSearchResults
+                  people={searchResults}
+                  columns={columns}
+                  selectedColumns={selectedColumns}
+                  updateSearchResults={(people) => setSearchResults(people)}
+                  updatedFunction={refetch}
+                />
               </Box>
             </Card>
           </Grid>

--- a/src/people/components/PeopleSearch.tsx
+++ b/src/people/components/PeopleSearch.tsx
@@ -9,6 +9,7 @@ import { Search as SearchIcon } from "@mui/icons-material";
 interface Props {
   updateSearchResults: (people: PersonInterface[]) => void;
   updatedFunction?: () => void;
+  resetSearchResults?: () => void;
 }
 
 export function PeopleSearch(props: Props) {
@@ -28,6 +29,8 @@ export function PeopleSearch(props: Props) {
       ApiHelper.post("/people/advancedSearch", [condition], "MembershipApi").then((data) => {
         props.updateSearchResults(data.map((d: PersonInterface) => B1AdminPersonHelper.getExpandedPersonObject(d)));
       });
+    } else {
+      props.resetSearchResults?.();
     }
   }, [props]);
 

--- a/src/site/admin/elements/ElementEdit.tsx
+++ b/src/site/admin/elements/ElementEdit.tsx
@@ -186,6 +186,44 @@ export function ElementEdit(props: Props) {
     <StylesAnimations fields={fields} styles={parsedStyles} onStylesChange={handleStyleChange} animations={parsedAnimations} onAnimationsChange={handleAnimationChange} />
   );
 
+  const getRichTextEditor = (field: string) => (
+    <Box
+      sx={{
+        mt: 2,
+        "& .editor-container": {
+          border: "1px solid #e5e7eb",
+          borderRadius: 1,
+          overflow: "hidden",
+          backgroundColor: "#fff"
+        },
+        "& .toolbar": {
+          p: 1,
+          gap: 0.5,
+          alignItems: "center"
+        },
+        "& .editor-inner": {
+          minHeight: 260
+        },
+        "& .editor-scroller": {
+          minHeight: 180,
+          maxHeight: 320,
+          overflowY: "auto"
+        },
+        "& .editor-input": {
+          minHeight: 180,
+          padding: "12px"
+        }
+      }}
+    >
+      <HtmlEditor
+        value={parsedData[field] || ""}
+        onChange={(val) => {
+          handleHtmlChange(field, val);
+        }}
+      />
+    </Box>
+  );
+
   const getBoxFields = () => (
     <>
       <FormControlLabel control={<Checkbox onChange={handleCheck} checked={parsedData.rounded === "true" ? true : false} />} name="rounded" label={Locale.label("site.elements.roundedCorners")} />
@@ -208,15 +246,7 @@ export function ElementEdit(props: Props) {
   const getTextFields = () => (
     <>
       {getTextAlignment("textAlignment")}
-      <Box sx={{ marginTop: 2 }}>
-        <HtmlEditor
-          value={parsedData.text || ""}
-          onChange={(val) => {
-            handleHtmlChange("text", val);
-          }}
-          style={{ maxHeight: 200, overflowY: "scroll" }}
-        />
-      </Box>
+      {getRichTextEditor("text")}
       {getAppearanceFields(["font", "color", "line", "margin", "padding", "text"])}
     </>
   );
@@ -270,15 +300,7 @@ export function ElementEdit(props: Props) {
         </Select>
       </FormControl>
       {getTextAlignment("textAlignment")}
-      <Box sx={{ marginTop: 2 }}>
-        <HtmlEditor
-          value={parsedData.text || ""}
-          onChange={(val) => {
-            handleHtmlChange("text", val);
-          }}
-          style={{ maxHeight: 200, overflowY: "scroll" }}
-        />
-      </Box>
+      {getRichTextEditor("text")}
       {getAppearanceFields([
         "border", "background", "color", "font", "height", "min", "max", "line", "margin", "padding", "text", "width"
       ])}
@@ -312,15 +334,7 @@ export function ElementEdit(props: Props) {
       {getTextAlignment("titleAlignment", Locale.label("site.elements.titleAlignment"))}
       <TextField fullWidth size="small" label={Locale.label("site.elements.title")} name="title" value={parsedData.title || ""} onChange={handleChange} onKeyDown={handleKeyDown} placeholder={Locale.label("placeholders.element.cardTitle")} />
       {getTextAlignment("textAlignment")}
-      <Box sx={{ marginTop: 2 }}>
-        <HtmlEditor
-          value={parsedData.text || ""}
-          onChange={(val) => {
-            handleHtmlChange("text", val);
-          }}
-          style={{ maxHeight: 200, overflowY: "scroll" }}
-        />
-      </Box>
+      {getRichTextEditor("text")}
       {getAppearanceFields([
         "border", "background", "color", "font", "height", "min", "max", "line", "margin", "padding", "text", "width"
       ])}


### PR DESCRIPTION
https://github.com/ChurchApps/ChurchAppsSupport/issues/859

- Space issue on Text area is resolved now
<img width="298" height="630" alt="image" src="https://github.com/user-attachments/assets/4a65cfbb-c4a4-4aea-9d48-b061597e9eab" />

------------

I also added an enhancement in the People section: previously, once a user performed a search, there was no way to easily return to the full list. Now, if the search field is cleared (left blank) and searched again, it reloads the complete user list — all without any UI changes.
