### PR TITLE
Enhancements on B1Admin

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1462,6 +1462,7 @@
       "valuePlaceholder": "Value"
     },
     "aiSearch": {
+      "clearSearch": "Clear Search",
       "exampleMen": "- Show me men over 30 with birthdays in July.",
       "exampleWomen": "- Show me women who are married.",
       "examples": "Examples:",

--- a/src/groups/GroupsPage.tsx
+++ b/src/groups/GroupsPage.tsx
@@ -9,6 +9,34 @@ import { useMountedState, Permissions } from "@churchapps/apphelper";
 import { useQuery } from "@tanstack/react-query";
 import { CountChip, ExportButton, SortableTableHead } from "../components/ui";
 
+const formatHeader = (key: string): string => {
+  const customMap: Record<string, string> = {
+    id: "ID",
+    churchId: "Church ID",
+    campusId: "Campus ID",
+    categoryName: "Category Name",
+    joinPolicy: "Join Policy",
+    labelCount: "Label Count",
+    memberCount: "Member Count",
+    meetingLocation: "Meeting Location",
+    meetingTime: "Meeting Time",
+    name: "Name",
+    labels: "Labels",
+    tags: "Tags"
+  };
+
+  if (customMap[key]) {
+    return customMap[key];
+  }
+
+  // Programmatic camelCase to spaced Title Case fallback
+  const result = key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/([0-9]+)/g, " $1")
+    .trim();
+  return result.charAt(0).toUpperCase() + result.slice(1);
+};
+
 const GroupsPage = () => {
   const [groups, setGroups] = useState<GroupInterface[]>([]);
   const [showAdd, setShowAdd] = useState(false);
@@ -56,7 +84,7 @@ const GroupsPage = () => {
   const exportData = groups.map((g) => {
     const { labelArray, ...rest } = g;
 
-    return {
+    const rawExport: any = {
       ...rest,
 
       labels: Array.isArray(labelArray)
@@ -69,6 +97,13 @@ const GroupsPage = () => {
 
       memberCount: Number(g.memberCount || 0)
     };
+
+    const formattedExport: any = {};
+    Object.keys(rawExport).forEach((key) => {
+      formattedExport[formatHeader(key)] = rawExport[key];
+    });
+
+    return formattedExport;
   });
 
   const getRows = () => {

--- a/src/people/PeoplePage.tsx
+++ b/src/people/PeoplePage.tsx
@@ -4,7 +4,7 @@ import { Permissions, UserHelper, type PersonInterface, type SearchCondition } f
 import { ApiHelper, Locale } from "@churchapps/apphelper";
 import { PeopleSearchResults, PeopleColumns } from "./components";
 import { Grid, Box, Typography, Card, Stack, Button, TextField, Dialog, DialogTitle, DialogContent, DialogActions, Snackbar, Alert, CircularProgress, Checkbox, FormControl, FormControlLabel, InputLabel, MenuItem, Select } from "@mui/material";
-import { B1AdminPersonHelper } from "../helpers";
+import { B1AdminPersonHelper, EnvironmentHelper } from "../helpers";
 import { PeopleSearch } from "./components/PeopleSearch";
 import { SavedLists, type ListConditions, type ListInterface } from "./components/SavedLists";
 import { buildRulesFromCriteria } from "./components/listRules";
@@ -25,6 +25,56 @@ interface BulkDeleteResponse {
 }
 
 const INITIAL_PAGE_SIZE = 50;
+
+const formatHeader = (key: string): string => {
+  const customMap: Record<string, string> = {
+    address: "Address",
+    address1: "Address 1",
+    address2: "Address 2",
+    age: "Age",
+    anniversary: "Anniversary",
+    birthDate: "Birth Date",
+    campusId: "Campus ID",
+    churchId: "Church ID",
+    city: "City",
+    contactCity: "Contact City",
+    contactEmail: "Contact Email",
+    contactState: "Contact State",
+    contactZip: "Contact Zip",
+    conversationId: "Conversation ID",
+    display: "Display Name",
+    first: "First Name",
+    last: "Last Name",
+    middle: "Middle Name",
+    middleName: "Middle Name",
+    mobilePhone: "Mobile Phone",
+    nametagNotes: "Nametag Notes",
+    nick: "Nick Name",
+    optedOut: "Opted Out",
+    phone: "Phone",
+    photo: "Photo",
+    photoUpdated: "Photo Updated",
+    state: "State",
+    workPhone: "Work Phone",
+    firstName: "First Name",
+    lastName: "Last Name",
+    gender: "Gender",
+    membershipStatus: "Membership Status",
+    id: "ID",
+    householdId: "Household ID"
+  };
+
+  if (customMap[key]) {
+    return customMap[key];
+  }
+
+  // Programmatic camelCase to spaced Title Case fallback
+  const result = key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/([0-9]+)/g, " $1")
+    .trim();
+  return result.charAt(0).toUpperCase() + result.slice(1);
+};
 
 export const PeoplePage = memo(() => {
   const [searchResults, setSearchResults] = React.useState<PersonInterface[] | null>(null);
@@ -259,9 +309,11 @@ export const PeoplePage = memo(() => {
   const getExportData = (people: PersonInterface[]) => {
     return people.map((person) => {
       const { name, contactInfo, ...rest } = person;
+      const photoUrl = person.photo ? (person.photo.startsWith("http") ? person.photo : (EnvironmentHelper.Common.ContentRoot + person.photo)) : "";
 
-      return {
+      const rawExport: any = {
         ...rest,
+        photo: photoUrl,
 
         display: name?.display,
         first: name?.first,
@@ -285,6 +337,13 @@ export const PeoplePage = memo(() => {
         contactZip: contactInfo?.zip,
         contactEmail: contactInfo?.email
       };
+
+      const formattedExport: any = {};
+      Object.keys(rawExport).forEach((key) => {
+        formattedExport[formatHeader(key)] = rawExport[key];
+      });
+
+      return formattedExport;
     });
   };
 
@@ -367,6 +426,7 @@ export const PeoplePage = memo(() => {
                 setIsSearchPerformed(true);
               }}
               onReportCriteria={setSaveableCriteria}
+              resetSearchResults={resetSearchResults}
             />
           </Grid>
           <Grid size={{ xs: 12, md: 9 }}>

--- a/src/people/PrintDirectoryPage.tsx
+++ b/src/people/PrintDirectoryPage.tsx
@@ -130,7 +130,7 @@ export const PrintDirectoryPage = () => {
     if (!people.isLoading && households.length > 0) {
       const t = setTimeout(() => {
         window.print();
-        navigate(-1);
+        navigate("/people");
       }, 1500);
       return () => clearTimeout(t);
     }

--- a/src/people/components/AISearch.tsx
+++ b/src/people/components/AISearch.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 import { type SearchCondition, type PersonInterface } from "@churchapps/helpers";
 import { ApiHelper, DisplayBox, ErrorMessages, Locale } from "@churchapps/apphelper";
-import { Button, TextField, Typography } from "@mui/material";
+import { Button, Stack, TextField, Typography } from "@mui/material";
 import { B1AdminPersonHelper } from "../../helpers";
 
 interface Props {
   updateSearchResults: (people: PersonInterface[]) => void;
   // Reports the AI-generated conditions so the parent can offer "Save as List".
   onReportCriteria?: (criteria: SearchCondition[] | null) => void;
+  resetSearchResults?: () => void;
 }
 
 export const AISearch = (props: Props) => {
   const [text, setText] = React.useState<string>("");
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [isSearched, setIsSearched] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<string[]>([]);
 
   const handleSearch = async (e: any) => {
@@ -27,13 +29,21 @@ export const AISearch = (props: Props) => {
 
       props.updateSearchResults(response?.map((p: PersonInterface) => B1AdminPersonHelper.getExpandedPersonObject(p)));
       if (filters?.length) props.onReportCriteria?.(filters);
+      setIsSearched(true);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setErrors([message]);
     } finally {
       setIsLoading(false);
-      setText("");
     }
+  };
+
+  const handleClear = () => {
+    setText("");
+    setIsSearched(false);
+    setErrors([]);
+    props.onReportCriteria?.(null);
+    props.resetSearchResults?.();
   };
 
   return (
@@ -56,9 +66,16 @@ export const AISearch = (props: Props) => {
         {Locale.label("people.aiSearch.exampleMen")}
         <br />{Locale.label("people.aiSearch.exampleWomen")}
       </Typography>
-      <Button fullWidth variant="contained" onClick={handleSearch} disabled={isLoading || !text || text === ""}>
-        {isLoading ? Locale.label("people.aiSearch.searching") : Locale.label("people.aiSearch.search")}
-      </Button>
+      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+        <Button fullWidth variant="contained" onClick={handleSearch} disabled={isLoading || !text || text === ""} sx={{ flex: 1 }}>
+          {isLoading ? Locale.label("people.aiSearch.searching") : Locale.label("people.aiSearch.search")}
+        </Button>
+        {(text || isSearched) && (
+          <Button fullWidth variant="outlined" onClick={handleClear} disabled={isLoading} sx={{ flex: 1 }} data-testid="ai-search-clear">
+            {Locale.label("people.aiSearch.clearSearch", "Clear Search")}
+          </Button>
+        )}
+      </Stack>
     </DisplayBox>
   );
 };

--- a/src/sermons/components/Sermons.tsx
+++ b/src/sermons/components/Sermons.tsx
@@ -352,11 +352,17 @@ export const Sermons = () => {
     </div>
   );
 
-  if (currentSermon !== null) return <SermonEdit currentSermon={currentSermon} updatedFunction={handleUpdated} />;
+  if (currentSermon !== null) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <SermonEdit currentSermon={currentSermon} updatedFunction={handleUpdated} />
+      </Box>
+    );
+  }
 
   if (currentPlaylist !== null) {
     return (
-      <>
+      <Box sx={{ p: 3 }}>
         {imageEditor}
         <PlaylistEdit
           currentPlaylist={currentPlaylist}
@@ -364,7 +370,7 @@ export const Sermons = () => {
           showPhotoEditor={showPhotoEditor}
           updatedPhoto={(photoType === "playlist" && photoUrl) || null}
         />
-      </>
+      </Box>
     );
   }
 

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -101,6 +101,50 @@ test.describe("People Management", () => {
       await expect(page.locator("p").getByText("Married")).toBeVisible();
     });
 
+    test("should AI search for people, keep search text, and support clearing", async ({ page }) => {
+      // Mock the AskApi call to /query/people
+      await page.route("**/query/people", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([{ field: "gender", operator: "equals", value: "Male" }])
+        });
+      });
+
+      // Mock the MembershipApi call to /people/advancedSearch
+      await page.route("**/people/advancedSearch", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            { id: "1", name: { display: "Donald Clark", first: "Donald", last: "Clark" }, contactInfo: { email: "donald@example.com" } }
+          ])
+        });
+      });
+
+      const searchInput = page.locator('[id="display-box"] textarea').first();
+      await searchInput.fill("show me users that contain 'gol'");
+
+      const searchBtn = page.locator('[id="display-box"] button').getByText("Search").first();
+      await expect(searchBtn).toBeEnabled();
+      await searchBtn.click();
+
+      // Check if search results are displayed
+      const donaldRow = page.locator("table tbody tr").filter({ hasText: "Donald Clark" }).first();
+      await expect(donaldRow).toBeVisible({ timeout: 10000 });
+
+      // Verify input value is NOT cleared
+      await expect(searchInput).toHaveValue("show me users that contain 'gol'");
+
+      // Clear search should restore original list
+      const clearBtn = page.getByTestId("ai-search-clear");
+      await expect(clearBtn).toBeVisible();
+      await clearBtn.click();
+
+      // Verify input value IS cleared
+      await expect(searchInput).toHaveValue("");
+    });
+
     test("should open notes tab", async ({ page }) => {
       await openPersonRow(page, SEED_PEOPLE.DONALD);
       const notesBtn = page.locator("button").getByText("Notes");


### PR DESCRIPTION
### **B1Admin Enhancements**

- [x] **Search AI Query Issue**
    * Fixed an issue where users were unable to clear the search query or return to the original unfiltered data.
    * Added a Clear Search button.
    * Search state now persists the query until the user manually clears it, improving readability and making it easier to review previous searches.


- [x] **CSV Group Member Image URL Issue**
    * Fixed an issue where the CSV export only included the image path and ID `(e.g., /pPFcmBNwJF5/membership/people/L5uLQN8E-yL.png?dt=1778824838000).`
    * CSV exports now include the complete image URL `(e.g., https://content.churchapps.org/pPFcmBNwJF5/membership/people/L5uLQN8E-yL.png?dt=1778824838000).`

- [x] **CSV Title Enhancements**      
     * For Eg. Prev birthDay will be Birth Day For people list export section      
     *  Implemented on `/groups` page     
     * Also in `/people` page

- [x] **Print Directory Navigation:**
    * Before: Cancelling or completing the Directory print process left the user stuck on a blank tab.
    * After: The tab now redirects cleanly to the `/people` directory, keeping the user in the application flow.

- [x]  **/sermons page** 
    - Before: The Sermon and Playlist edit forms stretched edge-to-edge across the entire browser viewport, lacking the standard page padding. 
  - After: Wrapped both edit forms in a <Box sx={{ p: 3 }}> container, applying a consistent 24px margin to all sides to match the rest of the application layout.

<img width="1349" height="79" alt="Screenshot 2026-06-24 at 2 54 33 PM" src="https://github.com/user-attachments/assets/01c212e7-4cf2-4be5-bcb9-95069f8c9b68" />

<img width="1369" height="241" alt="Screenshot 2026-06-24 at 2 53 12 PM" src="https://github.com/user-attachments/assets/849143c2-1c1e-47c8-afcd-b9055d9368a3" />
