### PR TITLE
Enhancements on admin pages

### DIFF
--- a/src/calendars/AvailabilityPage.tsx
+++ b/src/calendars/AvailabilityPage.tsx
@@ -124,7 +124,7 @@ export const AvailabilityPage = () => {
       </PageHeader>
       <Box sx={{ p: 3 }}>
         <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
-          <TextField select size="small" label={Locale.label("calendars.availability.filter")} value={filter} onChange={(e) => setFilter(e.target.value)} sx={{ minWidth: 240 }} data-testid="availability-filter">
+          <TextField select size="small" label={Locale.label("calendars.availability.filter")} value={filter} onChange={(e) => setFilter(e.target.value)} sx={{ minWidth: 240 }} data-testid="availability-filter" SelectProps={{ displayEmpty: true }}>
             <MenuItem value="">{Locale.label("calendars.availability.allRoomsResources")}</MenuItem>
             {rooms.map((r) => <MenuItem key={r.id} value={"room:" + r.id}>{r.name}</MenuItem>)}
             {resources.map((r) => <MenuItem key={r.id} value={"resource:" + r.id}>{r.name}</MenuItem>)}

--- a/src/components/ui/FormCard.tsx
+++ b/src/components/ui/FormCard.tsx
@@ -20,6 +20,7 @@ interface FormCardProps {
   headerActions?: ReactNode;
   stickyFooter?: boolean;
   "data-testid"?: string;
+  elevation?: number;
 }
 
 /** Card-based form shell: icon + h6 header, padded content, footer divider with
@@ -29,7 +30,8 @@ export const FormCard: React.FC<FormCardProps> = (props) => {
   const hasFooter = props.onSave || props.onCancel || props.onDelete;
 
   return (
-    <Card id={props.id} data-testid={props["data-testid"]} sx={{ mb: 3, position: "relative" }}>
+    <Card id={props.id} data-testid={props["data-testid"]} elevation={props.elevation} sx={{ mb: props.elevation === 0 ? 0 : 3, position: "relative" }}>
+
       {props.help && <HelpIcon article={props.help} />}
       <Box sx={{ p: 2, borderBottom: "1px solid var(--border-light)" }}>
         <Stack direction="row" justifyContent="space-between" alignItems="center">

--- a/src/serving/songs/components/Arrangement.tsx
+++ b/src/serving/songs/components/Arrangement.tsx
@@ -138,6 +138,8 @@ export const Arrangement = memo((props: Props) => {
               borderRadius: 1,
               p: 2,
               minHeight: 200,
+              maxHeight: 600,
+              overflowY: "auto",
               fontFamily: "monospace",
               fontSize: "0.875rem",
               lineHeight: 1.6,

--- a/src/serving/songs/components/ArrangementEdit.tsx
+++ b/src/serving/songs/components/ArrangementEdit.tsx
@@ -44,7 +44,9 @@ export const ArrangementEdit = (props: Props) => {
       <TextField label={Locale.label("songs.details.meter") || "Meter"} fullWidth {...register("meter")} />
       <TextField label={Locale.label("songs.details.length") || "Length"} type="number" placeholder="seconds" fullWidth {...register("seconds", { valueAsNumber: true })} />
       <TextField label="Sequence" fullWidth placeholder="Verse 1, Chorus, Verse 2, Chorus, Bridge" {...register("sequence")} />
-      <TextField label={Locale.label("songs.arrangement.lyrics")} multiline fullWidth placeholder={Locale.label("placeholders.song.lyrics")} {...register("lyrics")} />
+      <TextField label={Locale.label("songs.arrangement.lyrics")} multiline fullWidth placeholder={Locale.label("placeholders.song.lyrics")} {...register("lyrics")} maxRows={25} sx={{ "& textarea": { maxHeight: 600, overflowY: "auto !important" } }} />
+
+
     </FormCard>
   );
 };

--- a/src/serving/songs/components/SongDetailLinksEdit.tsx
+++ b/src/serving/songs/components/SongDetailLinksEdit.tsx
@@ -94,7 +94,7 @@ export const SongDetailLinksEdit = (props: Props) => {
           {link.service}
         </button>
       </TableCell>
-      <TableCell>{link.serviceKey}</TableCell>
+      <TableCell sx={{ whiteSpace: "nowrap" }}>{link.serviceKey}</TableCell>
     </TableRow>
   );
 
@@ -139,15 +139,17 @@ export const SongDetailLinksEdit = (props: Props) => {
           </Stack>
         </Stack>
 
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>{Locale.label("songs.songDetailLinksEdit.service")}</TableCell>
-              <TableCell>{Locale.label("songs.songDetailLinksEdit.key")}</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>{songDetailLinks?.map((sd) => getRow(sd))}</TableBody>
-        </Table>
+        <Box sx={{ overflowX: "auto", width: "100%" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>{Locale.label("songs.songDetailLinksEdit.service")}</TableCell>
+                <TableCell>{Locale.label("songs.songDetailLinksEdit.key")}</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>{songDetailLinks?.map((sd) => getRow(sd))}</TableBody>
+          </Table>
+        </Box>
       </Box>
     );
   }

--- a/src/site/components/AddPageModal.tsx
+++ b/src/site/components/AddPageModal.tsx
@@ -335,7 +335,8 @@ export function AddPageModal(props: Props) {
     return (
 
       <Dialog open={true} onClose={props.onDone} className="dialogForm">
-        <FormCard id="dialogForm" title={(pageTemplate === "link") ? Locale.label("site.addPage.newLink") : Locale.label("site.addPage.newPage")} icon="article" onSave={handleSave} onCancel={handleCancel} data-testid="add-page-modal" isSubmitting={isSubmitting}>
+        <FormCard id="dialogForm" title={(pageTemplate === "link") ? Locale.label("site.addPage.newLink") : Locale.label("site.addPage.newPage")} icon="article" onSave={handleSave} onCancel={handleCancel} data-testid="add-page-modal" isSubmitting={isSubmitting} elevation={0}>
+
           <ErrorMessages errors={errors} />
 
           <InputLabel>{Locale.label("site.addPage.pageType")}</InputLabel>

--- a/src/site/components/CustomFileUpload.tsx
+++ b/src/site/components/CustomFileUpload.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useRef } from "react";
+import axios from "axios";
+import { LinearProgress, Box, Typography, Button, IconButton, Stack } from "@mui/material";
+import {
+  InsertDriveFile as FileIcon,
+  Cancel as CancelIcon,
+  CloudUpload as UploadIcon,
+  CheckCircle as CheckCircleIcon
+} from "@mui/icons-material";
+import { ApiHelper, Locale } from "@churchapps/apphelper";
+
+interface Props {
+  contentType: string;
+  contentId: string;
+  pendingSave: boolean;
+  saveCallback: (file: any) => void;
+}
+
+export function CustomFileUpload(props: Props) {
+  const [file] = useState<any>({});
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<number>(-1);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    if (e.target.files && e.target.files.length > 0) {
+      setUploadedFile(e.target.files[0]);
+    }
+  };
+
+  const handleClear = () => {
+    setUploadedFile(null);
+    setUploadProgress(-1);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const convertBase64 = (): Promise<string | ArrayBuffer | null> =>
+    new Promise((resolve, reject) => {
+      if (!uploadedFile) return resolve(null);
+      const fileReader = new FileReader();
+      fileReader.readAsDataURL(uploadedFile);
+      fileReader.onload = () => {
+        resolve(fileReader.result);
+      };
+      fileReader.onerror = (error) => {
+        reject(error);
+      };
+    });
+
+  const handleSave = async () => {
+    if (!uploadedFile) return;
+    const f: any = { ...file };
+    f.size = uploadedFile.size;
+    f.fileType = uploadedFile.type;
+    f.fileName = uploadedFile.name;
+    f.contentType = props.contentType;
+    f.contentId = props.contentId;
+
+    const preUploaded = await preUpload();
+    if (!preUploaded) {
+      const base64 = await convertBase64();
+      f.fileContents = base64;
+    }
+    const data = await ApiHelper.post("/files", [f], "ContentApi");
+    handleClear();
+    props.saveCallback(data[0]);
+  };
+
+  const checkSave = () => {
+    if (props.pendingSave) {
+      if (uploadedFile && uploadedFile.size > 0) {
+        handleSave();
+      } else {
+        props.saveCallback(file);
+      }
+    }
+  };
+
+  const preUpload = async () => {
+    if (!uploadedFile) return false;
+    const params = {
+      fileName: uploadedFile.name,
+      contentType: props.contentType,
+      contentId: props.contentId
+    };
+    const presigned = await ApiHelper.post("/files/postUrl", params, "ContentApi");
+    const doUpload = presigned.key !== undefined;
+    if (doUpload) await postPresignedFile(presigned);
+    return doUpload;
+  };
+
+  const postPresignedFile = (presigned: any) => {
+    if (!uploadedFile) return;
+    const formData = new FormData();
+    formData.append("acl", "public-read");
+    formData.append("Content-Type", uploadedFile.type);
+    for (const property in presigned.fields) {
+      formData.append(property, presigned.fields[property]);
+    }
+    formData.append("file", uploadedFile);
+
+    const axiosConfig = {
+      headers: { "Content-Type": "multipart/form-data" },
+      onUploadProgress: (progressEvent: any) => {
+        if (progressEvent.total) {
+          setUploadProgress(
+            Math.round((100 * progressEvent.loaded) / progressEvent.total)
+          );
+        }
+      }
+    };
+    return axios.post(presigned.url, formData, axiosConfig);
+  };
+
+  useEffect(checkSave, [props.pendingSave]);
+
+
+
+  if (uploadedFile) {
+    const isUploading = uploadProgress > -1 && props.pendingSave;
+    return (
+      <Box
+        sx={{
+          border: "2px dashed",
+          borderColor: "#3dc13c",
+          backgroundColor: "rgba(61, 193, 60, 0.2)",
+          color: "#278e26",
+          borderRadius: 2,
+          p: 3,
+          animation: "fadeIn 0.3s ease",
+          transition: "all 0.2s ease"
+        }}
+      >
+        <Stack spacing={1.5} sx={{ width: "100%" }}>
+          <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between" sx={{ overflow: "hidden" }}>
+            <Stack direction="row" spacing={1.5} alignItems="center" sx={{ overflow: "hidden" }}>
+              <CheckCircleIcon sx={{ color: "#278e26" }} />
+              <FileIcon sx={{ color: "#278e26" }} />
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 500,
+                  textOverflow: "ellipsis",
+                  overflow: "hidden",
+                  whiteSpace: "nowrap"
+                }}
+              >
+                {uploadedFile.name}
+              </Typography>
+            </Stack>
+            {!isUploading && (
+              <IconButton size="small" onClick={handleClear} sx={{ color: "#278e26" }}>
+                <CancelIcon />
+              </IconButton>
+            )}
+          </Stack>
+          {isUploading && (
+            <Box sx={{ width: "100%" }}>
+              <LinearProgress variant="determinate" value={uploadProgress} sx={{ height: 4, borderRadius: 2, backgroundColor: "#ffffff", "& .MuiLinearProgress-bar": { backgroundColor: "#278e26" } }} />
+              <Typography variant="caption" sx={{ color: "#278e26", display: "block", mt: 0.5, textAlign: "right", fontWeight: "bold" }}>
+                {uploadProgress}%
+              </Typography>
+            </Box>
+          )}
+
+
+        </Stack>
+      </Box>
+    );
+  }
+
+
+
+  return (
+    <Box
+      sx={{
+        border: "2px dashed",
+        borderColor: "divider",
+        borderRadius: 2,
+        p: 3,
+        textAlign: "center",
+        "&:hover": { borderColor: "primary.main", backgroundColor: "action.hover" },
+        transition: "all 0.2s ease"
+      }}
+    >
+      <input
+        id="fileUpload"
+        type="file"
+        ref={fileInputRef}
+        onChange={handleChange}
+        style={{ display: "none" }}
+        data-testid="file-upload-input"
+      />
+      <Button
+        variant="outlined"
+        color="primary"
+        startIcon={<UploadIcon />}
+        onClick={() => fileInputRef.current?.click()}
+        data-testid="choose-file-btn"
+      >
+        {Locale.label("fileUpload.chooseFile", "Choose File")}
+      </Button>
+    </Box>
+  );
+}
+

--- a/src/site/components/FilesManager.tsx
+++ b/src/site/components/FilesManager.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import type { FileInterface } from "../../helpers/Interfaces";
 import { Box, Grid, Table, TableBody, TableCell, TableHead, TableRow, Typography, Stack, LinearProgress } from "@mui/material";
-import { FileUpload, ApiHelper, Locale } from "@churchapps/apphelper";
+import { ApiHelper, Locale } from "@churchapps/apphelper";
 import { Folder as FolderIcon, InsertDriveFile as FileIcon, Delete as DeleteIcon } from "@mui/icons-material";
 import { CardWithHeader, CountChip, EmptyState, FormCard } from "../../components/ui";
 import { AppIconButton } from "../../components/ui/AppIconButton";
+import { CustomFileUpload } from "./CustomFileUpload";
+
 
 export function FilesManager() {
   const [pendingFileSave, setPendingFileSave] = useState(false);
@@ -121,23 +123,14 @@ export function FilesManager() {
           </CardWithHeader>
         </Grid>
         <Grid size={{ md: 4, xs: 12 }}>
-          <FormCard icon="cloud_upload" title={Locale.label("site.files.uploadFiles")} onSave={handleSave} saveText={Locale.label("site.files.upload")} data-testid="file-upload-inputbox">
+          <FormCard icon="cloud_upload" title={Locale.label("site.files.uploadFiles")} onSave={handleSave} saveText={Locale.label("site.files.upload")} data-testid="file-upload-inputbox" isSubmitting={pendingFileSave}>
+
             {getStorage()}
             <Typography variant="body2" sx={{ mb: 2, color: "text.secondary" }}>
               {Locale.label("site.files.storageInfo")}
             </Typography>
             {usedSpace < 100000000 && (
-              <Box sx={{
-                border: "2px dashed",
-                borderColor: "divider",
-                borderRadius: 2,
-                p: 3,
-                textAlign: "center",
-                "&:hover": { borderColor: "primary.main", backgroundColor: "action.hover" },
-                transition: "all 0.2s ease"
-              }}>
-                <FileUpload contentType="website" contentId="" pendingSave={pendingFileSave} saveCallback={handleFileSaved} />
-              </Box>
+              <CustomFileUpload contentType="website" contentId="" pendingSave={pendingFileSave} saveCallback={handleFileSaved} />
             )}
           </FormCard>
         </Grid>

--- a/src/site/components/NavLinkEdit.tsx
+++ b/src/site/components/NavLinkEdit.tsx
@@ -87,7 +87,8 @@ export function NavLinkEdit(props: Props) {
   if (!props.link) return <></>;
   return (
     <Dialog open={true} onClose={props.onDone} style={{ minWidth: 800 }} sx={{ zIndex: 2000 }}>
-      <FormCard id="pageDetailsBox" title={props.link?.id ? Locale.label("site.navLink.linkSettings") : Locale.label("site.navLink.addLink")} icon="article" onSave={handleSubmit(onValid)} onCancel={handleCancel} onDelete={handleDelete}>
+      <FormCard id="pageDetailsBox" title={props.link?.id ? Locale.label("site.navLink.linkSettings") : Locale.label("site.navLink.addLink")} icon="article" onSave={handleSubmit(onValid)} onCancel={handleCancel} onDelete={handleDelete} elevation={0}>
+
         {summaryErrors.length > 0 && <Alert severity="error" sx={{ mb: 2 }}>{summaryErrors.map((msg) => <div key={msg}>{msg}</div>)}</Alert>}
         <Controller name="url" control={control} render={({ field }) => (
           <Autocomplete disablePortal limitTags={3} freeSolo options={getPageOptions()} value={field.value} onChange={(_e: SyntheticEvent, value: string) => { field.onChange(value); }} onInputChange={(_e: SyntheticEvent, value: string) => { field.onChange(value); }} sx={{ width: 300 }} ListboxProps={{ style: { maxHeight: 150 } }} renderInput={(params) => <TextField {...params} size="small" fullWidth label={Locale.label("site.navLinkEdit.url")} name="linkUrl" />} />

--- a/src/site/components/PageLinkEdit.tsx
+++ b/src/site/components/PageLinkEdit.tsx
@@ -112,6 +112,8 @@ export function PageLinkEdit(props: Props) {
         onSave={handleSubmit(onValid)}
         onCancel={handleCancel}
         onDelete={handleDelete}
+        elevation={0}
+
         headerActions={
           props.page?.id && (
             <a href="about:blank" onClick={handleDuplicate}>


### PR DESCRIPTION
Enhancements
- ✅ Fixed an issue on the `/calendars/availability` page where the Room Resources section displayed a blank container when an initial value was selected.
- ✅ Fixed a UI shadow rendering issue in the Add Link modal on the `/site/pages` page.
- ✅ Improved the file upload experience on `/site/files` by adding upload success indicators, cancel upload functionality, and re-upload support.
- ✅ Improved the lyrics input experience on `/serving/songs/SON00000002` by adding a scrollable text area with a maximum height, preventing the container from expanding excessively when entering long lyrics.
- ✅ Improved the External Links section on `/serving/songs/SON00000002` by adding horizontal scrolling to prevent long key/value content from being cut off or appearing stuck within the container.
