### PR TITLE
Fixes on song page and Print Directory on people section

### DIFF
--- a/src/people/PrintDirectoryPage.tsx
+++ b/src/people/PrintDirectoryPage.tsx
@@ -423,7 +423,15 @@ export const PrintDirectoryPage = () => {
                     <div className="member-photos">
                       {h.members.map((m) => (
                         <div key={m.id} className="member-photo-block">
-                          <img className="member-photo" src={PersonHelper.getPhotoUrl(m)} alt="" />
+                          <img
+                            className="member-photo"
+                            src={PersonHelper.getPhotoUrl(m)}
+                            alt=""
+                            onError={(e) => {
+                              e.currentTarget.onerror = null;
+                              e.currentTarget.src = "/images/sample-profile.png";
+                            }}
+                          />
                           <div className="member-photo-name">{firstName(m)}</div>
                         </div>
                       ))}

--- a/src/people/components/PeopleColumns.tsx
+++ b/src/people/components/PeopleColumns.tsx
@@ -90,9 +90,11 @@ export const PeopleColumns = memo(function PeopleColumns(props: Props) {
         );
       case "custom":
         return (
-          <Grid container spacing={0.5} sx={{ minHeight: 323 }}>
-            {optionalColumns.length > 0 ? <>{optionalItems}</> : <div>{Locale.label("people.peopleColumns.noFilt")}</div>}
-          </Grid>
+          <Box sx={{ minHeight: 323 }}>
+            <Grid container spacing={0.5}>
+              {optionalColumns.length > 0 ? <>{optionalItems}</> : <div>{Locale.label("people.peopleColumns.noFilt")}</div>}
+            </Grid>
+          </Box>
         );
       default: return null;
     }

--- a/src/serving/songs/SongPage.tsx
+++ b/src/serving/songs/SongPage.tsx
@@ -63,10 +63,16 @@ export const SongPage = memo(() => {
         const updatedArrangement = arrangementResult.data.find((arr) => arr.id === selectedArrangement.id);
         if (updatedArrangement) {
           setSelectedArrangement(updatedArrangement);
+        } else {
+          const nextArrangement = arrangementResult.data.length > 0 ? arrangementResult.data[0] : null;
+          setSelectedArrangement(nextArrangement);
+          if (!nextArrangement) {
+            navigate("/serving/songs");
+          }
         }
       }
     }
-  }, [song, arrangements, songDetail, selectedArrangement?.id]);
+  }, [song, arrangements, songDetail, selectedArrangement?.id, navigate]);
 
   const handleDeleteSong = useCallback(() => {
     if (window.confirm(Locale.label("songs.deleteSong.confirm"))) {

--- a/src/serving/songs/components/Arrangement.tsx
+++ b/src/serving/songs/components/Arrangement.tsx
@@ -7,7 +7,6 @@ import { Edit as EditIcon, QueueMusic as ArrangementIcon } from "@mui/icons-mate
 import { AppIconButton } from "../../../components/ui/AppIconButton";
 import { Keys } from "./Keys";
 import { ArrangementEdit } from "./ArrangementEdit";
-import { useNavigate } from "react-router-dom";
 
 interface Props {
   arrangement: ArrangementInterface;
@@ -15,7 +14,6 @@ interface Props {
 }
 
 export const Arrangement = memo((props: Props) => {
-  const navigate = useNavigate();
   const [songDetail, setSongDetail] = React.useState<SongDetailInterface>(null);
   const canEdit = UserHelper.checkAccess(Permissions.contentApi.content.edit);
   const [edit, setEdit] = React.useState(false);
@@ -100,15 +98,11 @@ export const Arrangement = memo((props: Props) => {
   }, [songDetail?.praiseChartsId, props.arrangement, props.reload]);
 
   const handleSave = useCallback(
-    (arrangement: ArrangementInterface) => {
+    () => {
       setEdit(false);
-      if (arrangement) {
-        props.reload();
-      } else {
-        navigate("/serving/songs");
-      }
+      props.reload();
     },
-    [props.reload, navigate]
+    [props.reload]
   );
 
   const arrangementCard = useMemo(


### PR DESCRIPTION
Enhancements
-  ✅ Song Section Enhancement: Fixed the arrangement deletion flow. Previously, deleting an arrangement would navigate back to the previous screen and cause flickering. Now, the user stays on the same screen after deleting an arrangement. Only when the last remaining arrangement is deleted does the app navigate back to the Song List screen, providing a smoother and more user-friendly experience.
-  ✅ People Custom Filters: Removed unnecessary UI spacing in Custom Filters. Custom Filter items now use the same spacing and layout as Standard Filters.
- ✅ People Directory Print: Added a default profile image for users who do not have a profile picture. This prevents blank image placeholders.

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ff9b5abc-6342-4018-8ea3-263f25978656" />
