### PR TITLE
Service Order: thumbnails, auto video times, and row-based drag & drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@stripe/react-stripe-js": "^6.6.0",
+    "@stripe/stripe-js": "^9.8.0",
     "@tanstack/react-query-devtools": "^5.100.9",
     "@types/babel__core": "^7.20.5",
     "@types/react": "^19.2.14",

--- a/src/components/DraggableWrapper.tsx
+++ b/src/components/DraggableWrapper.tsx
@@ -8,17 +8,20 @@ type Props = {
   data: any;
   onDoubleClick?: () => void;
   draggingCallback?: (isDragging: boolean) => void;
+  /** When set, only the first descendant with this class starts a drag (the whole
+   * element still renders as the drag preview). Without it, the whole element drags. */
+  handleClassName?: string;
 };
 
 export function DraggableWrapper(props: Props) {
-  const { dndType, data, draggingCallback, onDoubleClick, children } = props;
+  const { dndType, data, draggingCallback, onDoubleClick, children, handleClassName } = props;
   const callbackRef = React.useRef(draggingCallback);
 
   useEffect(() => {
     callbackRef.current = draggingCallback;
   }, [draggingCallback]);
 
-  const [{ isDragging }, drag] = useDrag(
+  const [{ isDragging }, drag, preview] = useDrag(
     () => ({
       type: dndType,
       item: { data },
@@ -41,8 +44,16 @@ export function DraggableWrapper(props: Props) {
 
   return (
     <div
-      ref={(node) => { drag(node); }}
-      style={{ opacity, transition: "opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)", cursor: isDragging ? "grabbing" : "grab" }}
+      ref={(node) => {
+        if (handleClassName) {
+          preview(node);
+          const handle = node?.querySelector("." + handleClassName) as HTMLElement | null;
+          drag(handle || node);
+        } else {
+          drag(node);
+        }
+      }}
+      style={{ opacity, transition: "opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)", ...(handleClassName ? {} : { cursor: isDragging ? "grabbing" : "grab" }) }}
       className="dragButton"
       onDoubleClick={onDoubleClick}
       data-testid="draggable-wrapper"

--- a/src/serving/components/ActionDialog.tsx
+++ b/src/serving/components/ActionDialog.tsx
@@ -29,6 +29,13 @@ export const ActionDialog: React.FC<Props> = (props) => {
     fallbackUrl: props.downloadUrl
   });
 
+  // Provider download links often carry no file extension, so URL sniffing wrongly
+  // defaults videos to "image". The item name still has the extension — trust it.
+  const nameSaysVideo = /\.(mp4|webm|mov|m4v|avi|mkv)\s*$/i.test(props.contentName || "");
+  const effectiveMediaType = nameSaysVideo && (!content?.mediaType || content.mediaType === "image")
+    ? "video"
+    : content?.mediaType;
+
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       if (typeof event.data?.height === "number") {
@@ -48,7 +55,7 @@ export const ActionDialog: React.FC<Props> = (props) => {
       <DialogContent sx={{ p: 0, overflow: "hidden" }}>
         <ContentRenderer
           url={content?.url}
-          mediaType={content?.mediaType}
+          mediaType={effectiveMediaType}
           title={props.contentName}
           description={content?.description}
           loading={loading}

--- a/src/serving/components/LessonPreview.tsx
+++ b/src/serving/components/LessonPreview.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@churchapps/apphelper";
 import { type PlanItemInterface } from "../../helpers";
 import { getSectionDuration } from "./PlanUtils";
 import { PlanItem } from "./PlanItem";
+import { type ProviderMediaInfo } from "./planItemUtils";
 
 interface Props {
   lessonItems: PlanItemInterface[];
@@ -12,6 +13,7 @@ interface Props {
   associatedProviderId?: string;
   associatedContentPath?: string;
   ministryId?: string;
+  mediaLookup?: Record<string, ProviderMediaInfo>;
 }
 
 export const LessonPreview = memo((props: Props) => {
@@ -34,6 +36,7 @@ export const LessonPreview = memo((props: Props) => {
           associatedProviderId={props.associatedProviderId}
           associatedContentPath={props.associatedContentPath}
           ministryId={props.ministryId}
+          mediaLookup={props.mediaLookup}
         />
       );
       cumulativeTime += getSectionDuration(item);

--- a/src/serving/components/PlanItem.tsx
+++ b/src/serving/components/PlanItem.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { Box, Menu, MenuItem } from "@mui/material";
+import { Menu, MenuItem } from "@mui/material";
 import { FormatListBulleted as FormatListBulletedIcon, MenuBook as MenuBookIcon, MusicNote as MusicNoteIcon } from "@mui/icons-material";
 import { type PlanItemInterface } from "../../helpers";
 import { DraggableWrapper } from "../../components/DraggableWrapper";
-import { DroppableWrapper } from "../../components/DroppableWrapper";
+import { RowDropZone } from "./RowDropZone";
 import { type TimeInterface, type PlanItemTimeInterface } from "@churchapps/helpers";
 import { ApiHelper, Locale } from "@churchapps/apphelper";
 import { SongDialog } from "./SongDialog";
 import { LessonDialog } from "./LessonDialog";
-import { getNextChildSort } from "./planItemUtils";
+import { getNextChildSort, estimateSeconds, type ProviderMediaInfo } from "./planItemUtils";
 import { ActionDialog } from "./ActionDialog";
 import { ActionSelector } from "./ActionSelector";
 import { PlanItemHeader, PlanItemRow } from "./planItem/index";
@@ -29,6 +29,7 @@ interface Props {
   exclusions?: PlanItemTimeInterface[];
   selectedServiceTimeId?: string;
   excluded?: boolean;
+  mediaLookup?: Record<string, ProviderMediaInfo>;
 }
 
 export const PlanItem = React.memo((props: Props) => {
@@ -123,63 +124,34 @@ export const PlanItem = React.memo((props: Props) => {
     props.planItem.children?.forEach((c, index) => {
       const childStartTime = cumulativeTime;
       const childExcluded = c.itemType !== "header" && isChildExcluded(c.id || "");
+      const childPlanItem = (
+        <PlanItem key={c.id} planItem={c} setEditPlanItem={props.setEditPlanItem} readOnly={props.readOnly} showItemDrop={props.showItemDrop} onDragChange={props.onDragChange} onChange={props.onChange} startTime={childStartTime} associatedContentPath={props.associatedContentPath} associatedProviderId={props.associatedProviderId} ministryId={props.ministryId} serviceTime={props.serviceTime} exclusions={props.exclusions} selectedServiceTimeId={props.selectedServiceTimeId} excluded={childExcluded} mediaLookup={props.mediaLookup} />
+      );
       result.push(
         <React.Fragment key={c.id || `child-${index}`}>
-          {props.showItemDrop && (
-            <DroppableWrapper
+          {props.readOnly ? (
+            childPlanItem
+          ) : (
+            <RowDropZone
               accept="planItem"
-              onDrop={(item) => {
-                handleDrop(item, index + 0.5);
+              onDrop={(item, position) => {
+                handleDrop(item, index + (position === "before" ? 0.5 : 1.5));
               }}>
-              <Box
-                sx={{
-                  height: "30px",
-                  border: "2px dashed",
-                  borderColor: "primary.main",
-                  borderRadius: 1,
-                  backgroundColor: "primary.light",
-                  opacity: 0.3,
-                  mb: 0.5
-                }}
-              />
-            </DroppableWrapper>
+              <DraggableWrapper
+                dndType="planItem"
+                data={c}
+                handleClassName="dragHandle"
+                draggingCallback={(isDragging) => {
+                  if (props.onDragChange) props.onDragChange(isDragging);
+                }}>
+                {childPlanItem}
+              </DraggableWrapper>
+            </RowDropZone>
           )}
-
-          <DraggableWrapper
-            dndType="planItem"
-            data={c}
-            draggingCallback={(isDragging) => {
-              if (props.onDragChange) props.onDragChange(isDragging);
-            }}>
-            <PlanItem key={c.id} planItem={c} setEditPlanItem={props.setEditPlanItem} readOnly={props.readOnly} showItemDrop={props.showItemDrop} onDragChange={props.onDragChange} onChange={props.onChange} startTime={childStartTime} associatedContentPath={props.associatedContentPath} associatedProviderId={props.associatedProviderId} ministryId={props.ministryId} serviceTime={props.serviceTime} exclusions={props.exclusions} selectedServiceTimeId={props.selectedServiceTimeId} excluded={childExcluded} />
-          </DraggableWrapper>
         </React.Fragment>
       );
-      if (!childExcluded) cumulativeTime += c.seconds || 0;
+      if (!childExcluded) cumulativeTime += estimateSeconds(c, props.mediaLookup);
     });
-    if (props.showItemDrop) {
-      result.push(
-        <React.Fragment key="trailing-drop-zone">
-          <DroppableWrapper
-            accept="planItem"
-            onDrop={(item) => {
-              handleDrop(item, getNextChildSort(props.planItem.children));
-            }}>
-            <Box
-              sx={{
-                height: 30,
-                border: "2px dashed",
-                borderColor: "primary.main",
-                borderRadius: 1,
-                backgroundColor: "primary.light",
-                opacity: 0.3,
-                mb: 0.5
-              }}
-            />
-          </DroppableWrapper>
-        </React.Fragment>
-      );
-    }
     return result;
   };
 
@@ -191,6 +163,16 @@ export const PlanItem = React.memo((props: Props) => {
       readOnly={props.readOnly}
       onAddClick={(e) => setAnchorEl(e.currentTarget)}
       onEditClick={() => props.setEditPlanItem(props.planItem)}
+      wrapRow={props.readOnly ? undefined : (row) => (
+        <RowDropZone
+          accept="planItem"
+          mode="into"
+          onDrop={(item) => {
+            handleDrop(item, 0.5);
+          }}>
+          {row}
+        </RowDropZone>
+      )}
     >
       {getChildren()}
     </PlanItemHeader>
@@ -205,6 +187,7 @@ export const PlanItem = React.memo((props: Props) => {
       readOnly={props.readOnly}
       onLabelClick={onLabelClick}
       onEditClick={() => props.setEditPlanItem(props.planItem)}
+      mediaLookup={props.mediaLookup}
     />
   );
 

--- a/src/serving/components/RowDropZone.tsx
+++ b/src/serving/components/RowDropZone.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { useDrop } from "react-dnd";
+
+interface Props {
+  accept: string;
+  /** "reorder": drop above/below based on cursor half, shown as an insertion line.
+   *  "into": whole child is one target (e.g. a section header = add to that section). */
+  mode?: "reorder" | "into";
+  onDrop: (data: any, position: "before" | "after") => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Makes its child row a drop target for plan item drags. Unlike separate drop-zone
+ * boxes, rows are always targets, so nothing shifts or appears when a drag starts —
+ * a blue insertion line previews exactly where the item will land.
+ */
+export const RowDropZone: React.FC<Props> = ({ accept, mode = "reorder", onDrop, children }) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [hoverHalf, setHoverHalf] = React.useState<"before" | "after">("before");
+
+  const getHalf = (monitor: { getClientOffset: () => { y: number } | null }): "before" | "after" => {
+    const rect = ref.current?.getBoundingClientRect();
+    const y = monitor.getClientOffset()?.y;
+    if (!rect || y == null) return "after";
+    return y < rect.top + rect.height / 2 ? "before" : "after";
+  };
+
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept,
+    hover: (_item: any, monitor: any) => {
+      if (mode === "reorder") setHoverHalf(getHalf(monitor));
+    },
+    drop: (item: any, monitor: any) => {
+      onDrop(item, mode === "reorder" ? getHalf(monitor) : "after");
+    },
+    collect: (monitor) => ({ isOver: !!monitor.isOver({ shallow: true }) })
+  }), [accept, mode, onDrop]);
+
+  drop(ref);
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: "relative",
+        ...(mode === "into" && isOver
+          ? { outline: "2px solid var(--c1)", outlineOffset: -2, borderRadius: 4, background: "rgba(21, 101, 192, 0.06)" }
+          : {})
+      }}
+    >
+      {children}
+      {isOver && mode === "reorder" && (
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            [hoverHalf === "before" ? "top" : "bottom"]: -2,
+            height: 4,
+            background: "var(--c1)",
+            borderRadius: 2,
+            zIndex: 10,
+            pointerEvents: "none",
+            boxShadow: "0 0 4px rgba(21, 101, 192, 0.6)"
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/serving/components/ServiceOrder.tsx
+++ b/src/serving/components/ServiceOrder.tsx
@@ -16,10 +16,9 @@ import { PlanItem } from "./PlanItem";
 import { SaveTemplateDialog } from "./SaveTemplateDialog";
 import { LessonPreview } from "./LessonPreview";
 import { DraggableWrapper } from "../../components/DraggableWrapper";
-import { DroppableWrapper } from "../../components/DroppableWrapper";
-import { DroppableScroll } from "../../site/admin/DroppableScroll";
-import { getSectionDuration, formatTime } from "./PlanUtils";
-import { findThumbnailRecursive } from "./planItemUtils";
+import { RowDropZone } from "./RowDropZone";
+import { formatTime } from "./PlanUtils";
+import { findThumbnailRecursive, buildProviderMediaLookup, matchProviderMedia, isVideoMedia, getVideoDuration, estimateSeconds, type ProviderMediaInfo } from "./planItemUtils";
 
 interface Props {
   plan: PlanInterface;
@@ -90,6 +89,8 @@ export const ServiceOrder = memo((props: Props) => {
   const [exclusions, setExclusions] = React.useState<PlanItemTimeInterface[]>([]);
   const [selectedServiceTimeId, setSelectedServiceTimeId] = React.useState<string>("");
   const [showSaveTemplate, setShowSaveTemplate] = React.useState(false);
+  const [mediaLookup, setMediaLookup] = React.useState<Record<string, ProviderMediaInfo>>({});
+  const [settingTimes, setSettingTimes] = React.useState(false);
 
   // Get the provider dynamically based on plan's providerId
   const provider: IProvider | null = useMemo(() => {
@@ -99,10 +100,12 @@ export const ServiceOrder = memo((props: Props) => {
     return null;
   }, [props.plan?.providerId]);
 
-  // Calculate total plan duration
+  // Calculate total plan duration (includes ~5:00 planning estimates for untimed images)
   const totalDuration = useMemo(() => {
-    return planItems.reduce((total, item) => total + getSectionDuration(item), 0);
-  }, [planItems]);
+    const walk = (pi: PlanItemInterface): number =>
+      estimateSeconds(pi, mediaLookup) + (pi.children || []).reduce((sum, c) => sum + walk(c), 0);
+    return planItems.reduce((total, item) => total + walk(item), 0);
+  }, [planItems, mediaLookup]);
 
   const loadData = useCallback(async () => {
     if (props.plan?.id) {
@@ -284,19 +287,24 @@ export const ServiceOrder = memo((props: Props) => {
     }
   }, [hasAssociatedContent, getContentPath, provider, props.plan?.providerPlanName, props.plan?.ministryId, props.plan?.providerId]);
 
+  // Fetches provider instructions once per load: builds the fresh media lookup (thumbnails)
+  // for saved items, and doubles as the preview source when the plan has no items yet.
   const loadPreviewLessonItems = useCallback(async () => {
-    if (hasAssociatedContent && planItems.length === 0 && provider) {
+    if (hasAssociatedContent && provider) {
       try {
         const contentPath = getContentPath();
         if (!contentPath) {
           setPreviewLessonItems([]);
+          setMediaLookup({});
           return;
         }
 
         const currentProviderId = props.plan?.providerId;
         const instructions = await getProviderInstructions(provider, contentPath, props.plan?.ministryId, currentProviderId);
 
-        if (instructions?.items) {
+        setMediaLookup(instructions?.items ? buildProviderMediaLookup(instructions.items) : {});
+
+        if (instructions?.items && planItems.length === 0) {
           // Convert InstructionItems to PlanItemInterface for preview with providerId and providerPath
           const planItemsFromInstructions = instructions.items.map((item, index) => instructionToPlanItem(item, currentProviderId, contentPath, [index]));
           setPreviewLessonItems(planItemsFromInstructions);
@@ -310,8 +318,59 @@ export const ServiceOrder = memo((props: Props) => {
       }
     } else {
       setPreviewLessonItems([]);
+      setMediaLookup({});
     }
   }, [hasAssociatedContent, planItems.length, getContentPath, provider, props.plan?.providerId, props.plan?.ministryId]);
+
+  // Videos still at 0:00 get their real length saved; images intentionally stay at 0
+  // (playback leaves the volunteer in control — the plan shows a ~5:00 estimate instead).
+  const timeSyncTargets = useMemo(() => {
+    const targets: { item: PlanItemInterface; media: ProviderMediaInfo }[] = [];
+    const walk = (list: PlanItemInterface[]) => {
+      list.forEach((pi) => {
+        if (pi.id && pi.itemType !== "header" && (pi.seconds || 0) === 0) {
+          const media = matchProviderMedia(pi, mediaLookup);
+          if (media && isVideoMedia(pi.label, media)) targets.push({ item: pi, media });
+        }
+        if (pi.children) walk(pi.children);
+      });
+    };
+    walk(planItems);
+    return targets;
+  }, [planItems, mediaLookup]);
+
+  const handleSyncTimes = useCallback(async (targets: { item: PlanItemInterface; media: ProviderMediaInfo }[]) => {
+    if (targets.length === 0 || settingTimes) return;
+    setSettingTimes(true);
+    try {
+      const updates: PlanItemInterface[] = [];
+      // Sequential on purpose: each video loads its metadata over the network.
+      for (const { item, media } of targets) {
+        const seconds = media.seconds || await getVideoDuration(media.url);
+        if (seconds && seconds > 0) updates.push({ ...item, children: undefined, seconds: Math.round(seconds) });
+      }
+      if (updates.length > 0) {
+        await ApiHelper.post("/planItems", updates, "DoingApi");
+        loadData();
+      }
+    } catch (error) {
+      console.error("Error syncing times:", error);
+      setErrorMessage(Locale.label("plans.serviceOrder.autoSetTimesError") || "Failed to set times");
+    } finally {
+      setSettingTimes(false);
+    }
+  }, [settingTimes, loadData]);
+
+  // Auto-sync on load: fill in real video lengths without user action.
+  // Each item is only attempted once per session so unmeasurable videos can't loop.
+  const attemptedSyncIds = React.useRef<Set<string>>(new Set());
+  React.useEffect(() => {
+    if (!canEdit || settingTimes) return;
+    const pending = timeSyncTargets.filter((t) => t.item.id && !attemptedSyncIds.current.has(t.item.id));
+    if (pending.length === 0) return;
+    pending.forEach((t) => attemptedSyncIds.current.add(t.item.id!));
+    handleSyncTimes(pending);
+  }, [timeSyncTargets, canEdit, settingTimes, handleSyncTimes]);
 
   const handleAddContent = useCallback(() => {
     // Always show the LessonHeaderSelector - it now supports provider browsing
@@ -439,10 +498,10 @@ export const ServiceOrder = memo((props: Props) => {
   // Section duration that respects per-item exclusions for the selected service time.
   const effectiveSectionDuration = useCallback((item: PlanItemInterface): number => {
     if (item.itemType !== "header" && isItemExcluded(item.id || "")) return 0;
-    let total = item.itemType === "header" ? 0 : (item.seconds || 0);
+    let total = item.itemType === "header" ? 0 : estimateSeconds(item, mediaLookup);
     if (item.children) item.children.forEach((c) => { total += effectiveSectionDuration(c); });
     return total;
-  }, [isItemExcluded]);
+  }, [isItemExcluded, mediaLookup]);
 
   const renderPlanItems = () => {
     const result: JSX.Element[] = [];
@@ -454,53 +513,42 @@ export const ServiceOrder = memo((props: Props) => {
 
       result.push(
         <React.Fragment key={pi.id || `temp-${index}`}>
-          {canEdit && showHeaderDrop && (
-            <DroppableWrapper
-              accept="planItemHeader"
-              onDrop={(item) => {
-                handleDrop(item, index + 0.5);
-              }}>
-              <Box
-                sx={{
-                  height: 40,
-                  border: "2px dashed",
-                  borderColor: "primary.main",
-                  borderRadius: 1,
-                  backgroundColor: "primary.light",
-                  opacity: 0.3,
-                  mb: 1
-                }}
-              />
-            </DroppableWrapper>
-          )}
           {canEdit ? (
-            <DraggableWrapper
-              dndType="planItemHeader"
-              data={pi}
-              draggingCallback={(isDragging) => {
-                setShowHeaderDrop(isDragging);
+            <RowDropZone
+              accept="planItemHeader"
+              onDrop={(item, position) => {
+                handleDrop(item, index + (position === "before" ? 0.5 : 1.5));
               }}>
-              <PlanItem
-                planItem={pi}
-                setEditPlanItem={setEditPlanItem}
-                showItemDrop={showItemDrop}
-                onDragChange={(dragging) => {
-                  setShowItemDrop(dragging);
-                }}
-                onChange={() => {
-                  loadData();
-                  loadTimesAndExclusions();
-                }}
-                startTime={sectionStartTime}
-                associatedContentPath={hasAssociatedContent ? getContentPath() : undefined}
-                associatedProviderId={props.plan?.providerId}
-                ministryId={props.plan?.ministryId}
-                serviceTime={selectedServiceTime}
-                exclusions={exclusions}
-                selectedServiceTimeId={selectedServiceTimeId}
-                excluded={excluded}
-              />
-            </DraggableWrapper>
+              <DraggableWrapper
+                dndType="planItemHeader"
+                data={pi}
+                handleClassName="dragHandle"
+                draggingCallback={(isDragging) => {
+                  setShowHeaderDrop(isDragging);
+                }}>
+                <PlanItem
+                  planItem={pi}
+                  setEditPlanItem={setEditPlanItem}
+                  showItemDrop={showItemDrop}
+                  onDragChange={(dragging) => {
+                    setShowItemDrop(dragging);
+                  }}
+                  onChange={() => {
+                    loadData();
+                    loadTimesAndExclusions();
+                  }}
+                  startTime={sectionStartTime}
+                  associatedContentPath={hasAssociatedContent ? getContentPath() : undefined}
+                  associatedProviderId={props.plan?.providerId}
+                  ministryId={props.plan?.ministryId}
+                  serviceTime={selectedServiceTime}
+                  exclusions={exclusions}
+                  selectedServiceTimeId={selectedServiceTimeId}
+                  excluded={excluded}
+                  mediaLookup={mediaLookup}
+                />
+              </DraggableWrapper>
+            </RowDropZone>
           ) : (
             <PlanItem
               planItem={pi}
@@ -517,6 +565,7 @@ export const ServiceOrder = memo((props: Props) => {
               exclusions={exclusions}
               selectedServiceTimeId={selectedServiceTimeId}
               excluded={excluded}
+              mediaLookup={mediaLookup}
             />
           )}
         </React.Fragment>
@@ -527,6 +576,32 @@ export const ServiceOrder = memo((props: Props) => {
 
     return result;
   };
+
+  // While dragging, scroll the page when the cursor nears the top/bottom edge.
+  React.useEffect(() => {
+    if (!showHeaderDrop && !showItemDrop) return;
+    const EDGE = 130;
+    const MAX_SPEED = 24;
+    let lastY = -1;
+    let raf = 0;
+    const onDragOver = (e: DragEvent) => { lastY = e.clientY; };
+    const tick = () => {
+      if (lastY >= 0) {
+        if (lastY < EDGE) {
+          window.scrollBy(0, -MAX_SPEED * (1 - lastY / EDGE));
+        } else if (lastY > window.innerHeight - EDGE) {
+          window.scrollBy(0, MAX_SPEED * (1 - (window.innerHeight - lastY) / EDGE));
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    window.addEventListener("dragover", onDragOver);
+    raf = requestAnimationFrame(tick);
+    return () => {
+      window.removeEventListener("dragover", onDragOver);
+      cancelAnimationFrame(raf);
+    };
+  }, [showHeaderDrop, showItemDrop]);
 
   React.useEffect(() => {
     loadData();
@@ -605,6 +680,15 @@ export const ServiceOrder = memo((props: Props) => {
                   sx={{ fontWeight: 500 }}
                 />
               )}
+              {settingTimes && (
+                <Chip
+                  icon={<ScheduleIcon sx={{ fontSize: 18 }} />}
+                  label={Locale.label("plans.serviceOrder.settingTimes") || "Detecting video times..."}
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontWeight: 500 }}
+                />
+              )}
               {serviceTimes.length > 0 && (
                 <TextField
                   select
@@ -627,16 +711,6 @@ export const ServiceOrder = memo((props: Props) => {
           </Stack>
 
           <DndProvider backend={HTML5Backend}>
-            {(showHeaderDrop || showItemDrop) && (
-              <>
-                <div style={{ position: "fixed", bottom: "20px", left: "50%", transform: "translateX(-50%)", zIndex: 1000, width: "min(600px, 80%)" }}>
-                  <DroppableScroll direction="down" text={Locale.label("plans.serviceOrder.scrollDown")} acceptTypes={["planItemHeader", "planItem"]} />
-                </div>
-                <div style={{ position: "fixed", top: "20px", left: "50%", transform: "translateX(-50%)", zIndex: 1000, width: "min(600px, 80%)" }}>
-                  <DroppableScroll direction="up" text={Locale.label("plans.serviceOrder.scrollUp")} acceptTypes={["planItemHeader", "planItem"]} />
-                </div>
-              </>
-            )}
             {planItems.length === 0 ? (
               showPreviewMode ? (
                 <LessonPreview
@@ -646,6 +720,7 @@ export const ServiceOrder = memo((props: Props) => {
                   associatedProviderId={props.plan?.providerId}
                   associatedContentPath={getContentPath() || undefined}
                   ministryId={props.plan?.ministryId}
+                  mediaLookup={mediaLookup}
                 />
               ) : (
                 <Box
@@ -659,28 +734,7 @@ export const ServiceOrder = memo((props: Props) => {
                 </Box>
               )
             ) : (
-              <>
-                {renderPlanItems()}
-                {showHeaderDrop && (
-                  <DroppableWrapper
-                    accept="planItemHeader"
-                    onDrop={(item) => {
-                      handleDrop(item, planItems?.length + 1);
-                    }}>
-                    <Box
-                      sx={{
-                        height: 40,
-                        border: "2px dashed",
-                        borderColor: "primary.main",
-                        borderRadius: 1,
-                        backgroundColor: "primary.light",
-                        opacity: 0.3,
-                        mb: 1
-                      }}
-                    />
-                  </DroppableWrapper>
-                )}
-              </>
+              renderPlanItems()
             )}
           </DndProvider>
         </CardContent>

--- a/src/serving/components/planItem/PlanItemHeader.tsx
+++ b/src/serving/components/planItem/PlanItemHeader.tsx
@@ -13,6 +13,8 @@ interface Props {
   onAddClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onEditClick: () => void;
   children?: React.ReactNode;
+  /** Wraps just the header row (not the children), e.g. to make it a drop target. */
+  wrapRow?: (row: React.ReactNode) => React.ReactNode;
 }
 
 /** Section header row with drag handle, label, action buttons, and duration. */
@@ -23,50 +25,59 @@ export const PlanItemHeader: React.FC<Props> = ({
   readOnly,
   onAddClick,
   onEditClick,
-  children
+  children,
+  wrapRow
 }) => {
   const sectionDuration = getSectionDuration(planItem);
   const railLabel = serviceStartTime ? formatClockTime(serviceStartTime, startTime) : formatTime(startTime);
 
-  return (
-    <>
-      <Box className="planItemHeader" sx={{ display: "flex", alignItems: "center" }}>
-        <div className="timeRailCell">
-          <span className="timeRailLabel">{railLabel}</span>
-          <span className="timeRailDot" />
-          <span className="timeRailLine" />
-        </div>
-        {!readOnly && <DragIndicatorIcon className="dragHandle" sx={{ color: "text.secondary" }} />}
-        <Box component="span" sx={{ flex: 1 }}>{planItem.label}</Box>
-        <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0, ml: 1.5 }}>
-          {!readOnly && (
-            <>
-              <Box
-                component="button"
-                type="button"
-                className="actionButton"
-                onClick={onAddClick}
-                aria-label={Locale.label("plans.planItem.addItem") || "Add item to section"}
-                sx={{ border: 0, cursor: "pointer", color: "primary.main", background: "transparent" }}>
-                <AddIcon />
-              </Box>
-              <Box
-                component="button"
-                type="button"
-                className="actionButton"
-                onClick={onEditClick}
-                aria-label={Locale.label("plans.planItem.editSection") || "Edit section"}
-                sx={{ border: 0, cursor: "pointer", color: "primary.main", background: "transparent" }}>
-                <EditIcon />
-              </Box>
-            </>
-          )}
-          <ScheduleIcon sx={{ fontSize: 18, color: "text.secondary", visibility: sectionDuration > 0 ? "visible" : "hidden" }} />
-          <Box component="span" sx={{ color: "text.secondary", fontSize: "0.85rem", minWidth: 44, textAlign: "right" }}>
-            {sectionDuration > 0 ? formatTime(sectionDuration) : ""}
-          </Box>
+  const headerRow = (
+    <Box className="planItemHeader" sx={{ display: "flex", alignItems: "center" }}>
+      <div className="timeRailCell">
+        <span className="timeRailLabel">{railLabel}</span>
+        <span className="timeRailDot" />
+        <span className="timeRailLine" />
+      </div>
+      {!readOnly && (
+        <Box component="span" className="dragHandle" sx={{ display: "inline-flex", alignItems: "center", color: "text.secondary" }}>
+          <DragIndicatorIcon />
+        </Box>
+      )}
+      <Box component="span" sx={{ flex: 1 }}>{planItem.label}</Box>
+      <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0, ml: 1.5 }}>
+        {!readOnly && (
+          <>
+            <Box
+              component="button"
+              type="button"
+              className="actionButton"
+              onClick={onAddClick}
+              aria-label={Locale.label("plans.planItem.addItem") || "Add item to section"}
+              sx={{ border: 0, cursor: "pointer", color: "primary.main", background: "transparent" }}>
+              <AddIcon />
+            </Box>
+            <Box
+              component="button"
+              type="button"
+              className="actionButton"
+              onClick={onEditClick}
+              aria-label={Locale.label("plans.planItem.editSection") || "Edit section"}
+              sx={{ border: 0, cursor: "pointer", color: "primary.main", background: "transparent" }}>
+              <EditIcon />
+            </Box>
+          </>
+        )}
+        <ScheduleIcon sx={{ fontSize: 18, color: "text.secondary", visibility: sectionDuration > 0 ? "visible" : "hidden" }} />
+        <Box component="span" sx={{ color: "text.secondary", fontSize: "0.85rem", minWidth: 44, textAlign: "right" }}>
+          {sectionDuration > 0 ? formatTime(sectionDuration) : ""}
         </Box>
       </Box>
+    </Box>
+  );
+
+  return (
+    <>
+      {wrapRow ? wrapRow(headerRow) : headerRow}
       {children}
     </>
   );

--- a/src/serving/components/planItem/PlanItemRow.tsx
+++ b/src/serving/components/planItem/PlanItemRow.tsx
@@ -6,6 +6,7 @@ import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
 import { type PlanItemInterface } from "../../../helpers";
 import { formatTime, formatClockTime } from "../PlanUtils";
 import { PlanItemIcon } from "./PlanItemIcon";
+import { type ProviderMediaInfo, matchProviderMedia, isVideoMedia, estimateSeconds } from "../planItemUtils";
 
 interface Props {
   planItem: PlanItemInterface;
@@ -15,6 +16,7 @@ interface Props {
   readOnly?: boolean;
   onLabelClick?: () => void;
   onEditClick: () => void;
+  mediaLookup?: Record<string, ProviderMediaInfo>;
 }
 
 /**
@@ -27,9 +29,17 @@ export const PlanItemRow: React.FC<Props> = ({
   excluded,
   readOnly,
   onLabelClick,
-  onEditClick
+  onEditClick,
+  mediaLookup
 }) => {
   const railLabel = excluded ? "—" : (serviceStartTime ? formatClockTime(serviceStartTime, startTime) : formatTime(startTime));
+  const providerMedia = planItem.thumbnailUrl ? undefined : matchProviderMedia(planItem, mediaLookup);
+  const showVideoThumb = !!providerMedia && isVideoMedia(planItem.label, providerMedia);
+  // Untimed images show a planning estimate (~5:00) rather than an alarming 0:00 —
+  // stored seconds stay 0 so playback leaves the volunteer in control.
+  const storedSeconds = planItem.seconds ?? 0;
+  const estimatedSeconds = storedSeconds === 0 ? estimateSeconds(planItem, mediaLookup) : 0;
+  const isEstimate = estimatedSeconds > 0;
   return (
     <Box
       className={`planItem${onLabelClick ? " clickableRow" : ""}`}
@@ -42,11 +52,14 @@ export const PlanItemRow: React.FC<Props> = ({
         <span className="timeRailLine" />
       </div>
       {!readOnly && (
-        <DragIndicatorIcon
+        <Box
+          component="span"
           className="dragHandle rowControl"
-          sx={{ color: "text.secondary", flexShrink: 0 }}
-          onClick={(e) => e.stopPropagation()}
-        />
+          sx={{ display: "inline-flex", alignItems: "center", color: "text.secondary", flexShrink: 0 }}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        >
+          <DragIndicatorIcon />
+        </Box>
       )}
       <Box sx={{ width: 80, height: 45, mr: 1, flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
         {planItem.thumbnailUrl ? (
@@ -62,11 +75,40 @@ export const PlanItemRow: React.FC<Props> = ({
               }
             }}
           />
+        ) : providerMedia ? (
+          showVideoThumb ? (
+            <Box
+              component="video"
+              src={providerMedia.url}
+              preload="metadata"
+              muted
+              playsInline
+              // Browsers won't decode a frame until forced; seeking just past 0 paints the first frame without playing.
+              onLoadedMetadata={(e: React.SyntheticEvent<HTMLVideoElement>) => {
+                try { e.currentTarget.currentTime = 0.1; } catch { /* ignore */ }
+              }}
+              sx={{ width: 80, height: 45, objectFit: "cover", borderRadius: 2, pointerEvents: "none", backgroundColor: "grey.900" }}
+            />
+          ) : (
+            <Box
+              component="img"
+              src={providerMedia.url}
+              alt=""
+              loading="lazy"
+              sx={{ width: 80, height: 45, objectFit: "cover", borderRadius: 2 }}
+              onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                e.currentTarget.style.display = "none";
+                if (e.currentTarget.nextElementSibling) {
+                  (e.currentTarget.nextElementSibling as HTMLElement).style.display = "flex";
+                }
+              }}
+            />
+          )
         ) : null}
         <Box
           component="span"
           sx={{
-            display: planItem.thumbnailUrl ? "none" : "flex",
+            display: planItem.thumbnailUrl || providerMedia ? "none" : "flex",
             alignItems: "center",
             justifyContent: "center",
             width: 80,
@@ -107,18 +149,21 @@ export const PlanItemRow: React.FC<Props> = ({
             <EditIcon />
           </Box>
         )}
-        <ScheduleIcon sx={{ fontSize: 18, color: planItem.seconds === 0 ? "error.main" : "text.secondary" }} />
+        <ScheduleIcon sx={{ fontSize: 18, color: storedSeconds === 0 && !isEstimate ? "error.main" : "text.secondary" }} />
         <Box
           component="span"
-          title={Locale.label("plans.planItem.duration")}
+          title={isEstimate
+            ? (Locale.label("plans.planItem.estimatedDuration") || "Estimated — advances manually during class")
+            : Locale.label("plans.planItem.duration")}
           sx={{
-            color: planItem.seconds === 0 ? "error.main" : "text.secondary",
+            color: storedSeconds === 0 && !isEstimate ? "error.main" : "text.secondary",
+            fontStyle: isEstimate ? "italic" : "normal",
             fontSize: "0.85rem",
             minWidth: 44,
             textAlign: "right"
           }}
         >
-          {formatTime(planItem.seconds ?? 0)}
+          {isEstimate ? `~${formatTime(estimatedSeconds)}` : formatTime(storedSeconds)}
         </Box>
       </Box>
     </Box>

--- a/src/serving/components/planItemUtils.ts
+++ b/src/serving/components/planItemUtils.ts
@@ -21,6 +21,102 @@ export function getNextChildSort(children: PlanItemInterface[] | undefined | nul
   return (children?.length ?? 0) + 1;
 }
 
+/** Fresh media info for a provider item, fetched per page load (provider links can expire). */
+export interface ProviderMediaInfo {
+  url: string;
+  mediaType?: "video" | "image";
+  seconds?: number;
+}
+
+/** Returns the first descendant (or the item itself) that carries a downloadUrl. */
+export function findFileRecursive(item: InstructionItem): InstructionItem | undefined {
+  if (item.downloadUrl) return item;
+  if (item.children) {
+    for (const child of item.children) {
+      const found = findFileRecursive(child);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/** Match a plan item to its fresh provider media by content path, falling back to label. */
+export function matchProviderMedia(planItem: PlanItemInterface, lookup?: Record<string, ProviderMediaInfo>): ProviderMediaInfo | undefined {
+  if (!lookup) return undefined;
+  if (planItem.providerContentPath && lookup[planItem.providerContentPath]) return lookup[planItem.providerContentPath];
+  if (planItem.label && lookup["label:" + planItem.label]) return lookup["label:" + planItem.label];
+  return undefined;
+}
+
+const VIDEO_EXT_PATTERN = /\.(mp4|webm|mov|m4v|avi|mkv)\s*(\?|#|$)/i;
+
+/** Planning estimate for images. Stored seconds stay 0 so playback (FreePlay) leaves the
+ * volunteer in control; this value is display/schedule-math only. */
+export const ESTIMATED_IMAGE_SECONDS = 300;
+
+/** Effective seconds for schedule math: stored value, else the image planning estimate. */
+export function estimateSeconds(planItem: PlanItemInterface, lookup?: Record<string, ProviderMediaInfo>): number {
+  if (planItem.seconds && planItem.seconds > 0) return planItem.seconds;
+  if (planItem.itemType === "header") return 0;
+  const media = matchProviderMedia(planItem, lookup);
+  if (media && !isVideoMedia(planItem.label, media)) return ESTIMATED_IMAGE_SECONDS;
+  return 0;
+}
+
+/** Older provider versions omit mediaType, so also sniff the file extension from the label/url. */
+export function isVideoMedia(label: string | undefined, media: ProviderMediaInfo): boolean {
+  return media.mediaType === "video" || VIDEO_EXT_PATTERN.test(label || "") || VIDEO_EXT_PATTERN.test(media.url.split("?")[0]);
+}
+
+/** Reads a video's duration (seconds) by loading just its metadata. Resolves null on error/timeout. */
+export function getVideoDuration(url: string, timeoutMs = 15000): Promise<number | null> {
+  return new Promise((resolve) => {
+    const video = document.createElement("video");
+    let settled = false;
+    const done = (value: number | null) => {
+      if (settled) return;
+      settled = true;
+      video.removeAttribute("src");
+      video.load();
+      resolve(value);
+    };
+    const timer = setTimeout(() => done(null), timeoutMs);
+    video.preload = "metadata";
+    video.onloadedmetadata = () => {
+      clearTimeout(timer);
+      done(Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null);
+    };
+    video.onerror = () => {
+      clearTimeout(timer);
+      done(null);
+    };
+    video.src = url;
+  });
+}
+
+/**
+ * Builds a lookup of fresh media urls from a provider instructions tree.
+ * Keys: dot-notation content paths ("0.2.1", matching providerContentPath on saved
+ * plan items) plus "label:<label>" fallbacks for items saved before paths existed.
+ */
+export function buildProviderMediaLookup(items: InstructionItem[]): Record<string, ProviderMediaInfo> {
+  const lookup: Record<string, ProviderMediaInfo> = {};
+  const walk = (list: InstructionItem[], indices: number[]) => {
+    list.forEach((item, i) => {
+      const path = [...indices, i];
+      const file = findFileRecursive(item);
+      if (file?.downloadUrl) {
+        const info: ProviderMediaInfo = { url: file.downloadUrl, mediaType: file.mediaType, seconds: file.seconds ?? item.seconds };
+        lookup[path.join(".")] = info;
+        if (item.label && !lookup["label:" + item.label]) lookup["label:" + item.label] = info;
+      }
+      if (item.children) walk(item.children, path);
+    });
+  };
+  walk(items, []);
+  return lookup;
+}
+
 /** Item types: reads accept legacy aliases; writes emit current types only.
  * Mappings: lessonSection/section→providerSection, lessonAction/action→providerPresentation, lessonAddOn/addon/file→providerFile, song→arrangementKey. */
 export const ITEM_TYPES = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,6 +2009,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stripe/react-stripe-js@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "@stripe/react-stripe-js@npm:6.6.0"
+  dependencies:
+    prop-types: "npm:^15.7.2"
+  peerDependencies:
+    "@stripe/stripe-js": ">=9.5.0 <10.0.0"
+    react: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.8.0 <20.0.0"
+  checksum: 10c0/fb093073d19efb15c18cd4b4007b886bfff4bbee17b270fabb86c82e1dad0377ebb15d58bab37c41c3ea01599fc0a5117747611226ac232e1350ebbfeecb17a7
+  languageName: node
+  linkType: hard
+
+"@stripe/stripe-js@npm:^9.8.0":
+  version: 9.8.0
+  resolution: "@stripe/stripe-js@npm:9.8.0"
+  checksum: 10c0/90c473b938800a3c7f5794e052b22b2a277e1e61a1b54353a8117c3fd630e42cba2530d42ca12a9e06b674cd3ad5d74adf815b54763dc14726aeb05056592031
+  languageName: node
+  linkType: hard
+
 "@tanstack/query-core@npm:5.100.14":
   version: 5.100.14
   resolution: "@tanstack/query-core@npm:5.100.14"
@@ -2569,6 +2589,8 @@ __metadata:
     "@react-hook/window-size": "npm:^3.1.1"
     "@rolldown/plugin-babel": "npm:^0.2.3"
     "@sentry/react": "npm:^10.52.0"
+    "@stripe/react-stripe-js": "npm:^6.6.0"
+    "@stripe/stripe-js": "npm:^9.8.0"
     "@tanstack/react-query": "npm:^5.100.9"
     "@tanstack/react-query-devtools": "npm:^5.100.9"
     "@types/babel__core": "npm:^7.20.5"


### PR DESCRIPTION
Improvements to the Serving → Plans → Service Order screen, focused on Dropbox-based lessons (works for any provider).

## What changed

**Thumbnails on every row**
Provider media links are fetched fresh on each page load (Dropbox links expire in ~4h, so nothing is stored) and matched to rows by `providerContentPath`, falling back to label. Images render directly; videos paint a first frame via `<video preload="metadata">`.

**Durations**
- Videos still at 0:00 automatically get their real measured length saved on page load (only fills blanks — never overwrites a manually set time).
- Images intentionally stay at 0 stored seconds (FreePlay keeps the volunteer in control) but display an italic **~5:00** planning estimate; the time rail and class total include estimates so leaders can gauge class length.

**Drag & drop rework**
- Drag by the handle only — rows stay clickable for previews.
- Every row is a drop target: blue insertion line shows above/below based on cursor position. No more dashed drop boxes appearing mid-drag and shifting the layout.
- Drop an item onto a section header to add it into that section (works for empty sections).
- Window-edge auto-scroll replaces the floating scroll-up/scroll-down bars.

**Fixes**
- `.mp4` previews now use the video player: ActionDialog trusts the file-name extension since provider download links carry no extension (URL sniffing defaulted them to `<img>`).
- Added `@stripe/stripe-js` + `@stripe/react-stripe-js` devDependencies — optional peer deps of apphelper that Vite 8 fails hard on, which broke fresh installs (gray screen).

## Related
- Companion provider fix: ChurchApps/Packages#11. Once that ships, newly imported Dropbox items carry mediaType/seconds/thumbnail natively and the client-side fallbacks here simply stop being exercised.

## Testing
- `tsc --noEmit` clean, eslint clean on touched files
- Exercised manually against production APIs with a Dropbox-linked plan (images + mp4s): thumbnails, auto times, estimates, reordering within/between sections, preview playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)