### PR TITLE
Enhancements csv and people section

### DIFF
--- a/src/calendars/CalendarPage.tsx
+++ b/src/calendars/CalendarPage.tsx
@@ -26,8 +26,10 @@ import { HeaderPrimaryButton, HeaderSecondaryButton } from "../components/ui/hea
 const printStyles = `@media print {
   body * { visibility: hidden; }
   .print-area, .print-area * { visibility: visible; }
-  .print-area { position: absolute; left: 0; top: 0; width: 100%; border: none !important; }
-  .print-area .rbc-calendar { height: 9.5in !important; }
+  .print-area { position: absolute; left: 0; top: 0; width: 100%; border: none !important; box-shadow: none !important; }
+  .print-area .rbc-calendar { height: 7.8in !important; }
+  .print-area .rbc-calendar:has(.rbc-agenda-view) { height: auto !important; }
+  .print-area .no-print, .print-area .no-print *, .print-area .rbc-btn-group { display: none !important; }
 }`;
 
 export const CalendarPage = () => {

--- a/src/calendars/components/CuratedEventCalendar.tsx
+++ b/src/calendars/components/CuratedEventCalendar.tsx
@@ -96,7 +96,7 @@ export function CuratedEventCalendar(props: Props) {
 
   return (
     <div data-testid={props["data-testid"]}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" marginBottom="17px" marginTop="12px">
+      <Stack className="no-print" direction="row" justifyContent="space-between" alignItems="center" marginBottom="17px" marginTop="12px">
         <div>
           <Button
             startIcon={<LinkIcon />}

--- a/src/components/reporting/ReportOutput.tsx
+++ b/src/components/reporting/ReportOutput.tsx
@@ -235,6 +235,9 @@ export const ReportOutput = (props: Props) => {
                 margin: 0 !important;
                 padding: 0 !important;
               }
+              #display-box-actions {
+                display: none !important;
+              }
               #reportsBox {
                 padding-left: 24px !important;
                 padding-right: 24px !important;

--- a/src/forms/components/FormSubmissions.tsx
+++ b/src/forms/components/FormSubmissions.tsx
@@ -237,7 +237,7 @@ export const FormSubmissions: React.FC<Props> = memo((props) => {
   const editLinks = useMemo(() => {
     const formName = formSubmissions.data?.length ? formSubmissions.data[0].form?.name + ".csv" : "form_submissions.csv";
     return (
-      <Stack direction="row" spacing={1} alignItems="center">
+      <Stack direction="row" spacing={1} alignItems="center" className="no-print">
         <ExportButton data={summaryCsv} filename={formName} text={Locale.label("donations.donations.export")} />
         <button
           type="button"
@@ -286,6 +286,11 @@ export const FormSubmissions: React.FC<Props> = memo((props) => {
     <Grid container spacing={3}>
       <Grid size={{ xs: 12, md: 8 }} className="form-submission-summary">
         <div ref={contentRef} className="form-submission-summary">
+          <style>{`
+            @media print {
+              .no-print, #display-box-actions { display: none !important; }
+            }
+          `}</style>
           <DisplayBox headerText={Locale.label("forms.formSubmissions.subSum")} headerIcon="group" editContent={editLinks}>
             <Grid container spacing={3}>
               {summaryContent}

--- a/src/people/PeoplePage.tsx
+++ b/src/people/PeoplePage.tsx
@@ -155,8 +155,20 @@ export const PeoplePage = memo(() => {
   const handleToggleColumn = (key: string) => {
     const sc = [...selectedColumns];
     const index = sc.indexOf(key);
-    if (index === -1) sc.push(key);
-    else sc.splice(index, 1);
+    if (index === -1) {
+      sc.push(key);
+    } else {
+      if (sc.length === 1) {
+        if (key !== "displayName") {
+          sc.splice(index, 1);
+          sc.push("displayName");
+        } else {
+          return;
+        }
+      } else {
+        sc.splice(index, 1);
+      }
+    }
     localStorage.setItem("selectedColumns", JSON.stringify(sc));
     setSelectedColumns(sc);
   };

--- a/src/people/components/PeopleColumns.tsx
+++ b/src/people/components/PeopleColumns.tsx
@@ -36,6 +36,7 @@ export const PeopleColumns = memo(function PeopleColumns(props: Props) {
               <Checkbox
                 size="small"
                 checked={selectedClass === "checked"}
+                disabled={option.key === "displayName" && props.selectedColumns.length === 1 && props.selectedColumns[0] === "displayName"}
                 onChange={(e) => {
                   props.toggleColumn(e.target.name);
                 }}

--- a/src/people/components/PersonExportDialog.tsx
+++ b/src/people/components/PersonExportDialog.tsx
@@ -181,7 +181,10 @@ export const PersonExportDialog: React.FC<Props> = memo((props) => {
 
   const buildCsvValue = (value: unknown) => {
     const normalized = String(value ?? "");
-    return `"${normalized.replace(/"/g, "\"\"")}"`;
+    if (normalized.includes(",") || normalized.includes("\"") || normalized.includes("\n") || normalized.includes("\r")) {
+      return `"${normalized.replace(/"/g, "\"\"")}"`;
+    }
+    return normalized;
   };
 
   const exportButtonLabel = selectedFormIds.length === 0
@@ -193,18 +196,41 @@ export const PersonExportDialog: React.FC<Props> = memo((props) => {
 
     setExporting(true);
     try {
-      const rows = [
-        ...getBaseRows(),
-        ...filteredRows.map((row) => ({
-          section: "Form",
-          form: row.formName,
-          question: row.questionTitle,
-          answer: row.answerValue
-        }))
-      ];
+      const csvSections: string[][] = [];
 
-      const headers = ["section", "form", "question", "answer"];
-      const csv = [headers.map(buildCsvValue).join(","), ...rows.map((row) => headers.map((header) => buildCsvValue((row as Record<string, string>)[header])).join(","))].join("\n");
+      // 1. Person Section
+      const personHeader = ["Section", "Field", "Value"];
+      const personRows = getBaseRows().map((row) => [
+        "Person",
+        row.question,
+        row.answer
+      ]);
+      csvSections.push([
+        personHeader.map(buildCsvValue).join(","),
+        ...personRows.map((row) => row.map(buildCsvValue).join(","))
+      ]);
+
+      // 2. Form Sections
+      const selectedFormsWithData = formOptions.filter((f) => selectedFormIds.includes(f.id));
+      selectedFormsWithData.forEach((form) => {
+        const formRows = filteredRows.filter((row) => row.formId === form.id);
+        if (formRows.length > 0) {
+          const formHeader = ["Form", "Field", "Value"];
+          const formSectionRows = formRows.map((row) => [
+            row.formName,
+            row.questionTitle,
+            row.answerValue
+          ]);
+          csvSections.push([
+            formHeader.map(buildCsvValue).join(","),
+            ...formSectionRows.map((row) => row.map(buildCsvValue).join(","))
+          ]);
+        }
+      });
+
+      // Join sections with one blank row containing empty columns (,,)
+      const csv = csvSections.map((section) => section.join("\n")).join("\n,,\n");
+
       const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement("a");


### PR DESCRIPTION
Enhancements:
* Fixed print view issues for `calendars/CAL00000003` by hiding interactive elements (Subscribe, + button, navigation controls, and calendar tabs) and ensuring the complete calendar, including the last date row, displays correctly in print.
* Added a fallback for the People filter to always show the member Display Name when all fields are unchecked, preventing blank results.
* Fixed print view issues for `/forms/FRM00000003` by hiding interaction buttons and icons only in print output while keeping the web view unchanged.
* Fixed People CSV export to include form-related columns only for members with associated form data.
* Improved Member Details CSV export by separating Member Information and Form Data into structured sections, with individual sections for each submitted form.


