### PR TITLE
Fix Tasks and Workflows card alignment

### DIFF
--- a/src/serving/tasks/components/TaskList.tsx
+++ b/src/serving/tasks/components/TaskList.tsx
@@ -289,7 +289,7 @@ export const TaskList = memo((props: Props) => {
           borderRadius: 2,
           border: "1px solid",
           borderColor: "divider",
-          marginTop: 4
+          marginTop: showAdd ? 4 : 0
         }}>
         <CardContent>
           <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>


### PR DESCRIPTION
## What changed

- Apply the Tasks card's top margin only while the New Task editor is open.
- Align the Tasks and Workflows cards on the My Work desktop layout.
- Preserve spacing between the New Task editor and the Tasks card.

## Why

The Tasks card had an unconditional `marginTop: 4`, while the adjacent Workflows card had no top margin. This shifted the Tasks card 32px lower.

The margin is only needed when the New Task editor is rendered above the card.

## Testing

- `yarn build`
- `yarn exec eslint src/serving/tasks/components/TaskList.tsx`
- Verified both cards have the same top position at 1600×900
- Verified the cards stack without horizontal overflow at 899×900
- Verified opening Add Task retains the intended 32px editor-to-card gap
- Verified there are no browser console warnings or errors