### PR TITLE
Allow overriding B1App host port via B1APP_HOST_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
         NEXT_PUBLIC_MESSAGING_API_SOCKET: ${SOCKET_URL:-ws://localhost:8084}
         NEXT_PUBLIC_B1ADMIN_ROOT: ${B1ADMIN_URL:-http://localhost:3101}
     ports:
-      - "3000:3000"
+      - "${B1APP_HOST_PORT:-3000}:3000"
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- Parameterize the B1App published host port as `${B1APP_HOST_PORT:-3000}` so local Docker can avoid clashes with other apps on `:3000`.
- Default remains `3000`, matching upstream behavior.

## Test plan
- [ ] `docker compose config` shows `3200:3000` when `B1APP_HOST_PORT=3200` is set in `.env`
- [ ] Without the env var, port mapping stays `3000:3000`
- [ ] Stack still serves B1App after `docker compose up -d`