### PR TITLE
fix: handle orphaned song records when adding songs with long titles

### DIFF
--- a/src/serving/songs/SongPage.tsx
+++ b/src/serving/songs/SongPage.tsx
@@ -34,9 +34,12 @@ export const SongPage = memo(() => {
     enabled: !!params.id
   });
 
+  // If song record is missing/orphaned, fall back to arrangement's songDetailId for the title
+  const songDetailId = song.data?.songDetailId || arrangements.data?.[0]?.songDetailId;
+
   const songDetail = useQuery<SongDetailInterface>({
-    queryKey: ["/songDetails/" + song.data?.songDetailId, "ContentApi"],
-    enabled: !!song.data?.songDetailId
+    queryKey: ["/songDetails/" + songDetailId, "ContentApi"],
+    enabled: !!songDetailId
   });
 
   // Set selected arrangement when arrangements load; fall back to the first one when

--- a/src/serving/songs/SongsPage.tsx
+++ b/src/serving/songs/SongsPage.tsx
@@ -48,7 +48,15 @@ export const SongsPage = memo(() => {
       const existing = await ApiHelper.get("/arrangements/songDetail/" + songDetail.id, "ContentApi");
       if (existing.length > 0) {
         const song = await ApiHelper.get("/songs/" + existing[0].songId, "ContentApi");
-        selectedSong = song;
+        if (song?.id) {
+          // Song and arrangement both exist — use them
+          selectedSong = song;
+        } else {
+          // Arrangement exists but song record is missing (orphaned) — create it
+          const s: SongInterface = { name: songDetail.title, songDetailId: songDetail.id, dateAdded: new Date() };
+          const newSongs = await ApiHelper.post("/songs", [s], "ContentApi");
+          selectedSong = newSongs[0];
+        }
       } else {
         const s: SongInterface = { name: songDetail.title, songDetailId: songDetail.id, dateAdded: new Date() };
         const newSongs = await ApiHelper.post("/songs", [s], "ContentApi");


### PR DESCRIPTION
- SongsPage: when an arrangement exists but its song record is missing (orphaned due to previous failed DB insert), create the missing song record instead of navigating to /serving/songs/undefined
- SongPage: fall back to arrangement's songDetailId when song.data is empty so the page title loads correctly instead of staying 'Loading...'