### PR TITLE
Fix: Text in church on provider dropdown

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -3125,7 +3125,8 @@
       "saveError": "خطأ في حفظ إعدادات الرسائل النصية.",
       "textInChurchHelper": "قم بزيارة",
       "textInChurchHelperLink": "دعم Text In Church",
-      "textInChurchHelperSuffix": "لطلب وصول API للمطورين. بعد الموافقة، قم بإنشاء مفتاح API في إعدادات حسابك > قسم API للمطورين."
+      "textInChurchHelperSuffix": "لطلب وصول API للمطورين. بعد الموافقة، قم بإنشاء مفتاح API في إعدادات حسابك > قسم API للمطورين.",
+      "textInChurch": "نص في الكنيسة"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -3125,7 +3125,8 @@
       "saveError": "Chyba při ukládání nastavení SMS.",
       "textInChurchHelper": "Navštivte",
       "textInChurchHelperLink": "Podpora Text In Church",
-      "textInChurchHelperSuffix": "pro vyžádání vývojářského API přístupu. Po schválení vytvořte API klíč v Nastavení účtu > sekce Vývojářské API."
+      "textInChurchHelperSuffix": "pro vyžádání vývojářského API přístupu. Po schválení vytvořte API klíč v Nastavení účtu > sekce Vývojářské API.",
+      "textInChurch": "Text v církvi"
     },
     "userAdd": {
       "addTo": "Přidat do ",

--- a/public/locales/da.json
+++ b/public/locales/da.json
@@ -3125,7 +3125,8 @@
       "saveError": "Fejl ved lagring af sms-indstillinger.",
       "textInChurchHelper": "Besøg",
       "textInChurchHelperLink": "Text In Church Support",
-      "textInChurchHelperSuffix": "for at anmode om udvikler-API-adgang. Når det er godkendt, opret en API-nøgle i dine Kontoindstillinger > Udvikler-API-sektionen."
+      "textInChurchHelperSuffix": "for at anmode om udvikler-API-adgang. Når det er godkendt, opret en API-nøgle i dine Kontoindstillinger > Udvikler-API-sektionen.",
+      "textInChurch": "Tekst i kirken"
     },
     "userAdd": {
       "addTo": "Tilføj til ",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -3125,7 +3125,8 @@
       "saveError": "Fehler beim Speichern der SMS-Einstellungen.",
       "textInChurchHelper": "Besuchen Sie",
       "textInChurchHelperLink": "Text In Church Support",
-      "textInChurchHelperSuffix": "um Entwickler-API-Zugriff anzufordern. Nach der Genehmigung erstellen Sie einen API-Schlüssel in Ihren Kontoeinstellungen > Entwickler-API-Bereich."
+      "textInChurchHelperSuffix": "um Entwickler-API-Zugriff anzufordern. Nach der Genehmigung erstellen Sie einen API-Schlüssel in Ihren Kontoeinstellungen > Entwickler-API-Bereich.",
+      "textInChurch": "Text in der Kirche"
     },
     "userAdd": {
       "addTo": "Hinzufügen zu ",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3372,7 +3372,8 @@
       "ministryStuff": "MinistryStuff",
       "ministryStuffActive": "Your MinistryStuff texting subscription is active with {} credits remaining this cycle.",
       "ministryStuffHelper": "No API key needed. Texting credits come from your MinistryStuff subscription, linked to this church automatically. Manage your plan at",
-      "ministryStuffHelperLink": "ministrystuff.org"
+      "ministryStuffHelperLink": "ministrystuff.org",
+      "textInChurch": "Text In Church"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -3125,7 +3125,8 @@
       "saveError": "Error al guardar la configuración de mensajería.",
       "textInChurchHelper": "Visite",
       "textInChurchHelperLink": "Soporte de Text In Church",
-      "textInChurchHelperSuffix": "para solicitar acceso de API para desarrolladores. Una vez aprobado, cree una Clave API en su Configuración de Cuenta > sección de API para desarrolladores."
+      "textInChurchHelperSuffix": "para solicitar acceso de API para desarrolladores. Una vez aprobado, cree una Clave API en su Configuración de Cuenta > sección de API para desarrolladores.",
+      "textInChurch": "Texto en la Iglesia"
     },
     "userAdd": {
       "addTo": "Agregar A ",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -3125,7 +3125,8 @@
       "saveError": "Virhe tallennettaessa tekstiviestiasetuksia.",
       "textInChurchHelper": "Käy",
       "textInChurchHelperLink": "Text In Church -tuessa",
-      "textInChurchHelperSuffix": "pyytääksesi kehittäjän API-pääsyä. Kun se on hyväksytty, luo API-avain Tilin asetukset > Kehittäjän API -osiossa."
+      "textInChurchHelperSuffix": "pyytääksesi kehittäjän API-pääsyä. Kun se on hyväksytty, luo API-avain Tilin asetukset > Kehittäjän API -osiossa.",
+      "textInChurch": "Teksti kirkossa"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -3125,7 +3125,8 @@
       "saveError": "Erreur lors de l'enregistrement des paramètres SMS.",
       "textInChurchHelper": "Visitez",
       "textInChurchHelperLink": "Support Text In Church",
-      "textInChurchHelperSuffix": "pour demander l'accès à l'API développeur. Une fois approuvé, créez une clé API dans la section Paramètres de compte > API développeur."
+      "textInChurchHelperSuffix": "pour demander l'accès à l'API développeur. Une fois approuvé, créez une clé API dans la section Paramètres de compte > API développeur.",
+      "textInChurch": "Texte à l'église"
     },
     "userAdd": {
       "addTo": "Ajouter à ",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -3125,7 +3125,8 @@
       "saveError": "टेक्स्टिंग सेटिंग्स सहेजने में त्रुटि।",
       "textInChurchHelper": "जाएँ",
       "textInChurchHelperLink": "Text In Church सहायता",
-      "textInChurchHelperSuffix": "डेवलपर API पहुँच का अनुरोध करने के लिए। एक बार स्वीकृत होने पर, अपने खाता सेटिंग्स > डेवलपर API अनुभाग में एक API कुंजी बनाएं।"
+      "textInChurchHelperSuffix": "डेवलपर API पहुँच का अनुरोध करने के लिए। एक बार स्वीकृत होने पर, अपने खाता सेटिंग्स > डेवलपर API अनुभाग में एक API कुंजी बनाएं।",
+      "textInChurch": "चर्च में टेक्स्ट"
     },
     "userAdd": {
       "addTo": "इसमें जोड़ें ",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -3125,7 +3125,8 @@
       "saveError": "Hiba az üzenetküldési beállítások mentésekor.",
       "textInChurchHelper": "Látogasson el a",
       "textInChurchHelperLink": "Text In Church támogatási oldalra",
-      "textInChurchHelperSuffix": "fejlesztői API hozzáférés kéréséhez. Jóváhagyás után hozzon létre API kulcsot a Fiók beállítások > Fejlesztői API részben."
+      "textInChurchHelperSuffix": "fejlesztői API hozzáférés kéréséhez. Jóváhagyás után hozzon létre API kulcsot a Fiók beállítások > Fejlesztői API részben.",
+      "textInChurch": "Szöveg a templomban"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -3125,7 +3125,8 @@
       "saveError": "Kesalahan menyimpan pengaturan SMS.",
       "textInChurchHelper": "Kunjungi",
       "textInChurchHelperLink": "Dukungan Text In Church",
-      "textInChurchHelperSuffix": "untuk meminta akses API pengembang. Setelah disetujui, buat Kunci API di bagian Pengaturan Akun > API Pengembang."
+      "textInChurchHelperSuffix": "untuk meminta akses API pengembang. Setelah disetujui, buat Kunci API di bagian Pengaturan Akun > API Pengembang.",
+      "textInChurch": "Teks di Gereja"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -3125,7 +3125,8 @@
       "saveError": "Errore nel salvataggio delle impostazioni SMS.",
       "textInChurchHelper": "Visita",
       "textInChurchHelperLink": "Supporto Text In Church",
-      "textInChurchHelperSuffix": "per richiedere l'accesso API per sviluppatori. Una volta approvato, crea una chiave API nella sezione Impostazioni Account > API per Sviluppatori."
+      "textInChurchHelperSuffix": "per richiedere l'accesso API per sviluppatori. Una volta approvato, crea una chiave API nella sezione Impostazioni Account > API per Sviluppatori.",
+      "textInChurch": "Testo in Chiesa"
     },
     "userAdd": {
       "addTo": "Aggiungi a ",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -3125,7 +3125,8 @@
       "saveError": "テキスティング設定の保存中にエラーが発生しました。",
       "textInChurchHelper": "訪問",
       "textInChurchHelperLink": "Text In Churchサポート",
-      "textInChurchHelperSuffix": "開発者APIアクセスをリクエストするため。承認されたら、アカウント設定 > 開発者APIセクションでAPIキーを作成してください。"
+      "textInChurchHelperSuffix": "開発者APIアクセスをリクエストするため。承認されたら、アカウント設定 > 開発者APIセクションでAPIキーを作成してください。",
+      "textInChurch": "教会でのテキスト"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -3125,7 +3125,8 @@
       "saveError": "텍스팅 설정 저장 중 오류가 발생했습니다.",
       "textInChurchHelper": "방문",
       "textInChurchHelperLink": "Text In Church 지원",
-      "textInChurchHelperSuffix": "개발자 API 액세스를 요청합니다. 승인되면 계정 설정 > 개발자 API 섹션에서 API 키를 생성하세요."
+      "textInChurchHelperSuffix": "개발자 API 액세스를 요청합니다. 승인되면 계정 설정 > 개발자 API 섹션에서 API 키를 생성하세요.",
+      "textInChurch": "교회에서의 텍스트"
     },
     "userAdd": {
       "addTo": "다음에 추가 ",

--- a/public/locales/lt.json
+++ b/public/locales/lt.json
@@ -3125,7 +3125,8 @@
       "saveError": "Klaida išsaugant SMS žinučių nustatymus.",
       "textInChurchHelper": "Apsilankykite",
       "textInChurchHelperLink": "Text In Church palaikyme",
-      "textInChurchHelperSuffix": "kad paprašytumėte kūrėjo API prieigos. Patvirtinus, sukurkite API raktą savo Paskyros nustatymai > Kūrėjo API skiltyje."
+      "textInChurchHelperSuffix": "kad paprašytumėte kūrėjo API prieigos. Patvirtinus, sukurkite API raktą savo Paskyros nustatymai > Kūrėjo API skiltyje.",
+      "textInChurch": "Tekstas bažnyčioje"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -3125,7 +3125,8 @@
       "saveError": "Fout bij het opslaan van sms-instellingen.",
       "textInChurchHelper": "Bezoek",
       "textInChurchHelperLink": "Text In Church-ondersteuning",
-      "textInChurchHelperSuffix": "om ontwikkelaars-API-toegang aan te vragen. Eenmaal goedgekeurd, maak een API-sleutel aan in je Accountinstellingen > Ontwikkelaars-API-sectie."
+      "textInChurchHelperSuffix": "om ontwikkelaars-API-toegang aan te vragen. Eenmaal goedgekeurd, maak een API-sleutel aan in je Accountinstellingen > Ontwikkelaars-API-sectie.",
+      "textInChurch": "Tekst in de kerk"
     },
     "userAdd": {
       "addTo": "Toevoegen aan ",

--- a/public/locales/no.json
+++ b/public/locales/no.json
@@ -3125,7 +3125,8 @@
       "saveError": "Feil ved lagring av SMS-innstillinger.",
       "textInChurchHelper": "Besøk",
       "textInChurchHelperLink": "Text In Church-støtte",
-      "textInChurchHelperSuffix": "for å be om utvikler-API-tilgang. Når godkjent, opprett en API-nøkkel under Account Settings > Developer API."
+      "textInChurchHelperSuffix": "for å be om utvikler-API-tilgang. Når godkjent, opprett en API-nøkkel under Account Settings > Developer API.",
+      "textInChurch": "Tekst i kirken"
     },
     "userAdd": {
       "addTo": "Legg til i ",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -3125,7 +3125,8 @@
       "saveError": "Błąd zapisywania ustawień SMS.",
       "textInChurchHelper": "Odwiedź",
       "textInChurchHelperLink": "Pomoc Text In Church",
-      "textInChurchHelperSuffix": "aby poprosić o dostęp do API dla deweloperów. Po zatwierdzeniu utwórz klucz API w sekcji Account Settings > Developer API."
+      "textInChurchHelperSuffix": "aby poprosić o dostęp do API dla deweloperów. Po zatwierdzeniu utwórz klucz API w sekcji Account Settings > Developer API.",
+      "textInChurch": "Tekst w kościele"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -3125,7 +3125,8 @@
       "saveError": "Erro ao salvar configurações de SMS.",
       "textInChurchHelper": "Visite",
       "textInChurchHelperLink": "Suporte do Text In Church",
-      "textInChurchHelperSuffix": "para solicitar acesso à API de desenvolvedor. Após aprovado, crie uma Chave API em sua seção Account Settings > Developer API."
+      "textInChurchHelperSuffix": "para solicitar acesso à API de desenvolvedor. Após aprovado, crie uma Chave API em sua seção Account Settings > Developer API.",
+      "textInChurch": "Texto na Igreja"
     },
     "userAdd": {
       "addTo": "Adicionar a ",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -3125,7 +3125,8 @@
       "saveError": "Ошибка сохранения настроек SMS.",
       "textInChurchHelper": "Посетите",
       "textInChurchHelperLink": "Поддержку Text In Church",
-      "textInChurchHelperSuffix": "чтобы запросить доступ к API для разработчиков. После одобрения создайте API-ключ в разделе Account Settings > Developer API."
+      "textInChurchHelperSuffix": "чтобы запросить доступ к API для разработчиков. После одобрения создайте API-ключ в разделе Account Settings > Developer API.",
+      "textInChurch": "Текст в церкви"
     },
     "userAdd": {
       "addTo": "Добавить в ",

--- a/public/locales/sk.json
+++ b/public/locales/sk.json
@@ -3125,7 +3125,8 @@
       "saveError": "Chyba pri ukladaní nastavení SMS.",
       "textInChurchHelper": "Navštívte",
       "textInChurchHelperLink": "Podporu Text In Church",
-      "textInChurchHelperSuffix": "pre žiadosť o prístup k API pre vývojárov. Po schválení vytvorte API kľúč v sekcii Account Settings > Developer API."
+      "textInChurchHelperSuffix": "pre žiadosť o prístup k API pre vývojárov. Po schválení vytvorte API kľúč v sekcii Account Settings > Developer API.",
+      "textInChurch": "Text v cirkvi"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/sl.json
+++ b/public/locales/sl.json
@@ -3125,7 +3125,8 @@
       "saveError": "Napaka pri shranjevanju nastavitev SMS.",
       "textInChurchHelper": "Obišči",
       "textInChurchHelperLink": "Podporo Text In Church",
-      "textInChurchHelperSuffix": "za zahtevo dostopa do razvijalskega API. Po odobritvi ustvarite API ključ v razdelku Nastavitve računa > Razvijalski API."
+      "textInChurchHelperSuffix": "za zahtevo dostopa do razvijalskega API. Po odobritvi ustvarite API ključ v razdelku Nastavitve računa > Razvijalski API.",
+      "textInChurch": "Besedilo v cerkvi"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/sr.json
+++ b/public/locales/sr.json
@@ -3125,7 +3125,8 @@
       "saveError": "Грешка при чувању подешавања за СМС.",
       "textInChurchHelper": "Посетите",
       "textInChurchHelperLink": "Text In Church подршку",
-      "textInChurchHelperSuffix": "да захтевате приступ developer API. Када се одобри, креирајте API кључ у одељку Account Settings > Developer API."
+      "textInChurchHelperSuffix": "да захтевате приступ developer API. Када се одобри, креирајте API кључ у одељку Account Settings > Developer API.",
+      "textInChurch": "Текст у цркви"
     },
     "userAdd": {
       "addTo": "Додај у ",

--- a/public/locales/ss.json
+++ b/public/locales/ss.json
@@ -3368,7 +3368,8 @@
       "ministryStuff": "MinistryStuff",
       "ministryStuffActive": "Kubhaliswa kwakho kwekutfumela imiyalezo kwe-MinistryStuff kuyasebenta ngema-credit langu-{} lasele kulesigceme.",
       "ministryStuffHelper": "Akukho i-API key ledzingekako. Ema-credit ekutfumela imiyalezo asuka ekubhaliseni kwakho kwe-MinistryStuff, lokuhlotjiswe naleli bandla ngekutitentekela. Phatsa luhlelo lwakho ku",
-      "ministryStuffHelperLink": "ministrystuff.org"
+      "ministryStuffHelperLink": "ministrystuff.org",
+      "textInChurch": "Umbhalo eSontweni"
     },
     "userAdd": {
       "addTo": "Engeta Ku ",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -3125,7 +3125,8 @@
       "saveError": "Fel vid sparande av SMS-inställningar.",
       "textInChurchHelper": "Besök",
       "textInChurchHelperLink": "Text In Church-support",
-      "textInChurchHelperSuffix": "för att begära åtkomst till utvecklar-API. När det godkänts skapar du en API-nyckel i avsnittet Kontoinställningar > Utvecklar-API."
+      "textInChurchHelperSuffix": "för att begära åtkomst till utvecklar-API. När det godkänts skapar du en API-nyckel i avsnittet Kontoinställningar > Utvecklar-API.",
+      "textInChurch": "Text i kyrkan"
     },
     "userAdd": {
       "addTo": "Lägg till i ",

--- a/public/locales/tl.json
+++ b/public/locales/tl.json
@@ -3125,7 +3125,8 @@
       "saveError": "Error sa pag-save ng texting settings.",
       "textInChurchHelper": "Bisitahin",
       "textInChurchHelperLink": "Text In Church Support",
-      "textInChurchHelperSuffix": "upang humiling ng developer API access. Kapag naaprubahan, gumawa ng API Key sa iyong Account Settings > Developer API section."
+      "textInChurchHelperSuffix": "upang humiling ng developer API access. Kapag naaprubahan, gumawa ng API Key sa iyong Account Settings > Developer API section.",
+      "textInChurch": "Teksto sa Simbahan"
     },
     "userAdd": {
       "addTo": "Magdagdag sa ",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -3125,7 +3125,8 @@
       "saveError": "Mesajlaşma ayarları kaydedilirken hata oluştu.",
       "textInChurchHelper": "Ziyaret edin:",
       "textInChurchHelperLink": "Text In Church Destek",
-      "textInChurchHelperSuffix": "geliştirici API erişimi talep etmek için. Onaylandıktan sonra, Hesap Ayarları > Geliştirici API bölümünde bir API Anahtarı oluşturun."
+      "textInChurchHelperSuffix": "geliştirici API erişimi talep etmek için. Onaylandıktan sonra, Hesap Ayarları > Geliştirici API bölümünde bir API Anahtarı oluşturun.",
+      "textInChurch": "Kilisede Metin"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -3125,7 +3125,8 @@
       "saveError": "Помилка збереження налаштувань SMS.",
       "textInChurchHelper": "Відвідайте",
       "textInChurchHelperLink": "Підтримка Text In Church",
-      "textInChurchHelperSuffix": "щоб запросити доступ до API розробника. Після затвердження створіть API-ключ у розділі Налаштування облікового запису > Developer API."
+      "textInChurchHelperSuffix": "щоб запросити доступ до API розробника. Після затвердження створіть API-ключ у розділі Налаштування облікового запису > Developer API.",
+      "textInChurch": "Текст у церкві"
     },
     "userAdd": {
       "addTo": "Add To ",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -3125,7 +3125,8 @@
       "saveError": "Lỗi khi lưu cài đặt nhắn tin.",
       "textInChurchHelper": "Truy cập",
       "textInChurchHelperLink": "Hỗ trợ Text In Church",
-      "textInChurchHelperSuffix": "để yêu cầu quyền truy cập API nhà phát triển. Sau khi được chấp thuận, tạo Khóa API trong Cài đặt tài khoản > phần Developer API."
+      "textInChurchHelperSuffix": "để yêu cầu quyền truy cập API nhà phát triển. Sau khi được chấp thuận, tạo Khóa API trong Cài đặt tài khoản > phần Developer API.",
+      "textInChurch": "Văn bản trong nhà thờ"
     },
     "userAdd": {
       "addTo": "Thêm To ",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -3125,7 +3125,8 @@
       "saveError": "保存短信设置时出错。",
       "textInChurchHelper": "访问",
       "textInChurchHelperLink": "Text In Church 支持",
-      "textInChurchHelperSuffix": "申请开发者 API 访问权限。批准后，在您的“账户设置 > 开发者 API”部分创建 API 密钥。"
+      "textInChurchHelperSuffix": "申请开发者 API 访问权限。批准后，在您的“账户设置 > 开发者 API”部分创建 API 密钥。",
+      "textInChurch": "教会里的文本"
     },
     "userAdd": {
       "addTo": "添加到 ",

--- a/src/settings/components/TextingSettingsEdit.tsx
+++ b/src/settings/components/TextingSettingsEdit.tsx
@@ -121,6 +121,7 @@ export const TextingSettingsEdit: React.FC<Props> = (props) => {
               <MenuItem value="">{Locale.label("settings.textingSettingsEdit.none")}</MenuItem>
               {MINISTRYSTUFF_ENABLED && <MenuItem value="MinistryStuff">{Locale.label("settings.textingSettingsEdit.ministryStuff")}</MenuItem>}
               <MenuItem value="Clearstream">{Locale.label("settings.textingSettingsEdit.clearstream")}</MenuItem>
+              <MenuItem value="TextInChurch">{Locale.label("settings.textingSettingsEdit.textInChurch")}</MenuItem>
             </Select>
           </FormControl>
         </Grid>


### PR DESCRIPTION
With all supported languages.

<img width="489" height="303" alt="image" src="https://github.com/user-attachments/assets/f0a02836-380a-4009-b02e-db2244bbe928" />

https://github.com/ChurchApps/ChurchAppsSupport/issues/953