### PR TITLE
Fix Playwright failures against local B1Admin + Api

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -113,9 +113,6 @@ export const Header: React.FC = () => {
         "/sermons": "nav-item-sermons"
       };
 
-      // Only tag primary-nav chrome (header + drawer list items). Secondary-menu
-      // chips and in-page links (e.g. a task titled "Dashboard Task") must not
-      // inherit nav-item-* via text.includes().
       const scopes = document.querySelectorAll("header, .MuiDrawer-root");
       const navLinks = Array.from(scopes).flatMap((scope) => Array.from(scope.querySelectorAll('a[href^="/"], button[role="menuitem"], .MuiListItemButton-root')));
       navLinks.forEach((link) => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -113,7 +113,10 @@ export const Header: React.FC = () => {
         "/sermons": "nav-item-sermons"
       };
 
-      const navLinks = document.querySelectorAll('a[href^="/"], button[role="menuitem"]');
+      // Only tag header/drawer chrome. Page content links (e.g. a task titled
+      // "Dashboard Task") used to inherit nav-item-* via text.includes().
+      const scopes = document.querySelectorAll("header, .MuiDrawer-root, #secondaryMenu");
+      const navLinks = Array.from(scopes).flatMap((scope) => Array.from(scope.querySelectorAll('a[href^="/"], button[role="menuitem"], [role="button"]')));
       navLinks.forEach((link) => {
         const href = link.getAttribute("href");
         if (href && urlToTestId[href]) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -113,10 +113,11 @@ export const Header: React.FC = () => {
         "/sermons": "nav-item-sermons"
       };
 
-      // Only tag header/drawer chrome. Page content links (e.g. a task titled
-      // "Dashboard Task") used to inherit nav-item-* via text.includes().
-      const scopes = document.querySelectorAll("header, .MuiDrawer-root, #secondaryMenu");
-      const navLinks = Array.from(scopes).flatMap((scope) => Array.from(scope.querySelectorAll('a[href^="/"], button[role="menuitem"], [role="button"]')));
+      // Only tag primary-nav chrome (header + drawer list items). Secondary-menu
+      // chips and in-page links (e.g. a task titled "Dashboard Task") must not
+      // inherit nav-item-* via text.includes().
+      const scopes = document.querySelectorAll("header, .MuiDrawer-root");
+      const navLinks = Array.from(scopes).flatMap((scope) => Array.from(scope.querySelectorAll('a[href^="/"], button[role="menuitem"], .MuiListItemButton-root')));
       navLinks.forEach((link) => {
         const href = link.getAttribute("href");
         if (href && urlToTestId[href]) {

--- a/src/donations/CampaignPage.tsx
+++ b/src/donations/CampaignPage.tsx
@@ -8,7 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type CampaignInterface, type CampaignProgressInterface, type PledgeInterface, type PledgeProgressRowInterface, type PledgeStatus } from "../helpers";
 import { CampaignEdit, PledgeEdit } from "./components";
 import { AppIconButton } from "../components/ui/AppIconButton";
-import { Breadcrumbs, type BreadcrumbItem, CardWithHeader, EmptyState, ExportButton, SortableTableHead, HeaderPrimaryButton, HeaderSecondaryButton, hoverRowSx, type SortDirection } from "../components/ui";
+import { Breadcrumbs, type BreadcrumbItem, CardWithHeader, EmptyState, ExportButton, PageHeaderStats, SortableTableHead, HeaderPrimaryButton, HeaderSecondaryButton, hoverRowSx, type SortDirection } from "../components/ui";
 
 const statusColors: Record<PledgeStatus, "default" | "info" | "success" | "warning"> = {
   notStarted: "default",

--- a/src/donations/DonationBatchPage.tsx
+++ b/src/donations/DonationBatchPage.tsx
@@ -45,7 +45,7 @@ export const DonationBatchPage = () => {
   const getEditModules = () => {
     const result = [];
     if (editDonationId !== "notset") result.push(<DonationEdit key="donationEdit" donationId={editDonationId} updatedFunction={donationUpdated} funds={funds.data || []} batchId={batch.data?.id || ""} currency={currency} />);
-    if (editBatch && batch.data?.id) result.push(<BatchEdit key="batchEdit" batchId={batch.data.id} updatedFunction={batchUpdated} />);
+    if (editBatch && batch.data?.id) result.push(<BatchEdit key="batchEdit" batch={batch.data} updatedFunction={batchUpdated} />);
     return result;
   };
 

--- a/src/donations/DonationBatchesPage.tsx
+++ b/src/donations/DonationBatchesPage.tsx
@@ -24,10 +24,10 @@ export const DonationBatchesPage = () => {
 
   const { sorted: sortedBatches, sortBy, sortDirection, handleSort } = useSortableData<DonationBatchInterface>(batches.data || [], "", "asc", batchComparators);
 
-  const batchUpdated = () => {
+  const batchUpdated = React.useCallback(() => {
     setEditBatchId("notset");
     batches.refetch();
-  };
+  }, [batches]);
 
   const showEditBatch = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/donations/DonationBatchesPage.tsx
+++ b/src/donations/DonationBatchesPage.tsx
@@ -56,11 +56,7 @@ export const DonationBatchesPage = () => {
     }
   }, [batches.data]);
 
-  const getSidebarModules = () => {
-    const result = [];
-    if (editBatchId !== "notset") result.push(<BatchEdit key={result.length - 1} batchId={editBatchId} updatedFunction={batchUpdated} />);
-    return result;
-  };
+  const editBatch = editBatchId === "notset" ? undefined : editBatchId === "" ? {} : (sortedBatches.find((b) => b.id === editBatchId) || { id: editBatchId });
 
   const getRows = () => {
     const result: JSX.Element[] = [];
@@ -200,7 +196,7 @@ export const DonationBatchesPage = () => {
       </PageHeader>
 
       <Box sx={{ p: 3 }}>
-        {editBatchId !== "notset" && <Box sx={{ mb: 3 }}>{getSidebarModules()}</Box>}
+        {editBatch && <Box sx={{ mb: 3 }}><BatchEdit key={editBatchId || "new"} batch={editBatch} updatedFunction={batchUpdated} /></Box>}
 
         <CardWithHeader
           icon={<DonationIcon sx={{ color: "primary.main", fontSize: 20 }} />}

--- a/src/donations/DonationBatchesPage.tsx
+++ b/src/donations/DonationBatchesPage.tsx
@@ -24,10 +24,11 @@ export const DonationBatchesPage = () => {
 
   const { sorted: sortedBatches, sortBy, sortDirection, handleSort } = useSortableData<DonationBatchInterface>(batches.data || [], "", "asc", batchComparators);
 
+  const refetchBatches = batches.refetch;
   const batchUpdated = React.useCallback(() => {
     setEditBatchId("notset");
-    batches.refetch();
-  }, [batches]);
+    refetchBatches();
+  }, [refetchBatches]);
 
   const showEditBatch = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/donations/components/BatchEdit.tsx
+++ b/src/donations/components/BatchEdit.tsx
@@ -63,4 +63,4 @@ export const BatchEdit = memo((props: Props) => {
       </FormCard>
     </>
   );
-});
+}, (prev, next) => prev.batch?.id === next.batch?.id && prev.batch?.name === next.batch?.name && prev.batch?.batchDate === next.batch?.batchDate && prev.updatedFunction === next.updatedFunction);

--- a/src/donations/components/BatchEdit.tsx
+++ b/src/donations/components/BatchEdit.tsx
@@ -63,4 +63,4 @@ export const BatchEdit = memo((props: Props) => {
       </FormCard>
     </>
   );
-}, (prev, next) => prev.batch?.id === next.batch?.id && prev.batch?.name === next.batch?.name && prev.batch?.batchDate === next.batch?.batchDate && prev.updatedFunction === next.updatedFunction);
+}, (prev, next) => prev.batch?.id === next.batch?.id && prev.batch?.name === next.batch?.name && String(prev.batch?.batchDate || "") === String(next.batch?.batchDate || "") && prev.updatedFunction === next.updatedFunction);

--- a/src/donations/components/BatchEdit.tsx
+++ b/src/donations/components/BatchEdit.tsx
@@ -7,15 +7,21 @@ import { FormCard } from "../../components/ui";
 import { useConfirmDelete } from "../../hooks";
 
 interface Props {
-  batchId: string;
+  batch: DonationBatchInterface;
   updatedFunction: () => void;
 }
 
 type AnyRecord = Record<string, any>;
 
 export const BatchEdit = memo((props: Props) => {
-  "use no memo"; // compiler caches register() results, breaking RHF field re-registration after reset()
-  const { register, handleSubmit, reset } = useForm<AnyRecord>({ defaultValues: { name: "", date: DateHelper.formatHtml5Date(new Date()) } });
+  "use no memo";
+  const batchId = props.batch?.id || "";
+  const { register, handleSubmit } = useForm<AnyRecord>({
+    defaultValues: {
+      name: props.batch?.name || "",
+      date: props.batch?.batchDate ? DateHelper.formatHtml5Date(props.batch.batchDate) : DateHelper.formatHtml5Date(new Date())
+    }
+  });
 
   const { confirm, ConfirmDialogElement } = useConfirmDelete();
 
@@ -23,29 +29,17 @@ export const BatchEdit = memo((props: Props) => {
 
   const handleDelete = useCallback(async () => {
     if (await confirm(Locale.label("donations.batchEdit.confirmMsg"))) {
-      ApiHelper.delete("/donationbatches/" + props.batchId, "GivingApi").then(() => props.updatedFunction());
+      ApiHelper.delete("/donationbatches/" + batchId, "GivingApi").then(() => props.updatedFunction());
     }
-  }, [props.batchId, props.updatedFunction, confirm]);
+  }, [batchId, props.updatedFunction, confirm]);
 
-  const getDeleteFunction = useCallback(() => (!UniqueIdHelper.isMissing(props.batchId) ? handleDelete : undefined), [props.batchId, handleDelete]);
+  const getDeleteFunction = useCallback(() => (!UniqueIdHelper.isMissing(batchId) ? handleDelete : undefined), [batchId, handleDelete]);
 
   const onValid = useCallback((values: AnyRecord) => {
     const batchToSave: DonationBatchInterface = { name: values.name, batchDate: values.date ? DateHelper.formatHtml5Date(values.date) : undefined };
-    if (!UniqueIdHelper.isMissing(props.batchId)) batchToSave.id = props.batchId;
+    if (!UniqueIdHelper.isMissing(batchId)) batchToSave.id = batchId;
     return ApiHelper.post("/donationbatches", [batchToSave], "GivingApi").then(() => props.updatedFunction());
-  }, [props.batchId, props.updatedFunction]);
-
-  const loadData = useCallback(() => {
-    if (UniqueIdHelper.isMissing(props.batchId)) {
-      reset({ name: "", date: DateHelper.formatHtml5Date(new Date()) });
-    } else {
-      ApiHelper.get("/donationbatches/" + props.batchId, "GivingApi").then((data: DonationBatchInterface) => {
-        reset({ name: data.name, date: data.batchDate ? DateHelper.formatHtml5Date(data.batchDate) : "" });
-      });
-    }
-  }, [props.batchId, reset]);
-
-  React.useEffect(loadData, [loadData]);
+  }, [batchId, props.updatedFunction]);
 
   return (
     <>

--- a/src/settings/components/CampusesSection.tsx
+++ b/src/settings/components/CampusesSection.tsx
@@ -25,8 +25,6 @@ export const CampusesSection: React.FC = () => {
   if (campuses.isLoading) return <Loading />;
 
   const data = campuses.data || [];
-  // Keep the editor bound to the latest query row so a refetch after save
-  // (or a click that captured a stale list item) still shows persisted fields.
   const selectedCampus = editCampus?.id ? (data.find((c) => c.id === editCampus.id) ?? editCampus) : editCampus;
 
   const rows = data.map((c) => {

--- a/src/settings/components/CampusesSection.tsx
+++ b/src/settings/components/CampusesSection.tsx
@@ -25,6 +25,9 @@ export const CampusesSection: React.FC = () => {
   if (campuses.isLoading) return <Loading />;
 
   const data = campuses.data || [];
+  // Keep the editor bound to the latest query row so a refetch after save
+  // (or a click that captured a stale list item) still shows persisted fields.
+  const selectedCampus = editCampus?.id ? (data.find((c) => c.id === editCampus.id) ?? editCampus) : editCampus;
 
   const rows = data.map((c) => {
     const location = [c.city, c.state].filter(Boolean).join(", ");
@@ -85,9 +88,9 @@ export const CampusesSection: React.FC = () => {
           </Table>
         </SectionListCard>
       </Grid>
-      {editCampus && (
+      {selectedCampus && (
         <Grid size={{ xs: 12, md: 5 }}>
-          <CampusEdit campus={editCampus} updatedFunction={handleUpdated} />
+          <CampusEdit campus={selectedCampus} updatedFunction={handleUpdated} />
         </Grid>
       )}
     </Grid>

--- a/tests/attendance.spec.ts
+++ b/tests/attendance.spec.ts
@@ -91,7 +91,7 @@ test.describe("Attendance Management", () => {
   test("should view group from attendance homepage", async ({ page }) => {
     const groupBtn = page.locator("a").getByText("Worship").first();
     await groupBtn.click();
-    await page.waitForURL(/\/groups\/GRP\w+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
   });
 
   test.describe("Trends", () => {

--- a/tests/campus.spec.ts
+++ b/tests/campus.spec.ts
@@ -71,7 +71,9 @@ test.describe.serial("Campus multi-site", () => {
     await expect(city).toBeVisible({ timeout: 10000 });
     await city.fill("Northtown");
     await expectResponse("/campuses", saveInputBox("#campusBox"));
-    await page.locator("table tbody tr").filter({ hasText: NORTH }).first().click();
+    const northRow = page.locator("table tbody tr").filter({ hasText: NORTH }).first();
+    await expect(northRow).toContainText("Northtown", { timeout: 10000 });
+    await northRow.click();
     await expect(page.locator("#city")).toHaveValue("Northtown", { timeout: 10000 });
   });
 

--- a/tests/campus.spec.ts
+++ b/tests/campus.spec.ts
@@ -2,7 +2,7 @@ import type { Page, Locator } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import { login } from "./helpers/auth";
 import { navigateToSettings, navigateToPeople, navigateToGroups } from "./helpers/navigation";
-import { openKnownPerson, editIconButton, personDetailsEditButton, SEED_PEOPLE, confirmDelete } from "./helpers/fixtures";
+import { openKnownPerson, openSeedGroup, editIconButton, personDetailsEditButton, SEED_PEOPLE, confirmDelete } from "./helpers/fixtures";
 import { STORAGE_STATE_PATH } from "./global-setup";
 
 const MAIN = "Main Campus";
@@ -132,8 +132,7 @@ test.describe.serial("Campus multi-site", () => {
 
   test("assigns a group to a campus and persists", async () => {
     await navigateToGroups(page);
-    await page.locator("table tbody tr a").first().click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page);
     await editIconButton(page).first().click();
     const select = page.getByTestId("group-campus-select");
     await expect(select).toBeVisible({ timeout: 10000 });

--- a/tests/campus.spec.ts
+++ b/tests/campus.spec.ts
@@ -133,7 +133,7 @@ test.describe.serial("Campus multi-site", () => {
   test("assigns a group to a campus and persists", async () => {
     await navigateToGroups(page);
     await page.locator("table tbody tr a").first().click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await editIconButton(page).first().click();
     const select = page.getByTestId("group-campus-select");
     await expect(select).toBeVisible({ timeout: 10000 });

--- a/tests/checkin.spec.ts
+++ b/tests/checkin.spec.ts
@@ -4,12 +4,12 @@ import { editIconButton } from "./helpers/fixtures";
 test.describe("Check-in: group configuration", () => {
   test("opens a seeded group detail page from the list", async ({ page }) => {
     await page.getByRole("link", { name: "Sunday Morning Service", exact: true }).click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
   });
 
   test("displays Track Attendance, Parent Pickup, Print Nametag from seed", async ({ page }) => {
     await page.getByRole("link", { name: "Sunday Morning Service", exact: true }).click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     await expect(page.getByText("Track Attendance").first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Parent Pickup").first()).toBeVisible();
@@ -18,7 +18,7 @@ test.describe("Check-in: group configuration", () => {
 
   test("edit form exposes Track Attendance, Parent Pickup, Print Nametag selects", async ({ page }) => {
     await page.getByRole("link", { name: "Sunday Morning Service", exact: true }).click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     await editIconButton(page).first().click();
 
@@ -32,7 +32,7 @@ test.describe("Check-in: group configuration", () => {
 
   test("shows assigned service times for the group", async ({ page }) => {
     await page.getByRole("link", { name: "Sunday Morning Service", exact: true }).click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     await expect(page.getByText("9:00 AM Service").first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("10:30 AM Service").first()).toBeVisible();
@@ -40,7 +40,7 @@ test.describe("Check-in: group configuration", () => {
 
   test("edit form lists available service times for assignment", async ({ page }) => {
     await page.getByRole("link", { name: "Sunday Morning Service", exact: true }).click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     await editIconButton(page).first().click();
 
@@ -58,7 +58,7 @@ test.describe("Check-in: group configuration", () => {
 
   test("saves a Parent Pickup toggle and reflects it in the display", async ({ page }) => {
     await page.getByRole("link", { name: "Sunday Morning Service", exact: true }).click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     // Target role=combobox, not [name="parentPickup"] (hidden native input).
     const parentPickupCombo = page.locator("#mui-component-select-parentPickup");

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -28,7 +28,7 @@ test.describe("Dashboard Management", () => {
     const firstGroupLink = page.locator('a[href^="/groups/GRP"]').first();
     await expect(firstGroupLink).toBeVisible({ timeout: 10000 });
     await firstGroupLink.click();
-    await expect(page).toHaveURL(/\/groups\/GRP\w+/, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000 });
   });
 
   test("should search people from dashboard", async ({ page }) => {

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -40,9 +40,8 @@ test.describe("Dashboard Management", () => {
     const results = page.getByRole("link", { name: "Dorothy Jackson" }).first();
     await expect(results).toBeVisible({ timeout: 10000 });
     await results.click();
-    await expect(page).toHaveURL(/\/people\/PER\w+/, { timeout: 10000 });
-    const validatedName = page.locator("p").getByText("Dorothy Jackson");
-    await expect(validatedName).toHaveCount(1);
+    await expect(page).toHaveURL(/\/people\/(?!demographics|lists)[^/?#]+/, { timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "Dorothy Jackson" }).first()).toBeVisible();
   });
 
   test("should show empty state when no people match search", async ({ page }) => {

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -110,34 +110,24 @@ test.describe.serial("Donations Management", () => {
 
     test("should edit batch", async () => {
       await openBatchesTab(page);
-
-      const row = page.locator("tr").filter({ has: page.locator("a").getByText(TEST_BATCH_INITIAL, { exact: true }) });
-      const editBtn = row.getByRole("button", { name: /Edit/ });
-      await row.scrollIntoViewIfNeeded();
-      await row.hover();
-      await expect(editBtn).toBeVisible({ timeout: 10000 });
-      await editBtn.click({ force: true });
-
+      const batchLink = page.getByRole("link", { name: TEST_BATCH_INITIAL, exact: true });
+      await expect(batchLink).toBeVisible({ timeout: 10000 });
+      await page.locator("tr", { has: batchLink }).getByRole("button", { name: "Edit" }).click();
       const batchName = page.locator("#batchBox [name=\"name\"]");
       await expect(batchName).toBeVisible({ timeout: 10000 });
       await expect(batchName).toHaveValue(TEST_BATCH_INITIAL, { timeout: 10000 });
       await batchName.fill(TEST_BATCH_RENAMED);
       await page.locator("#batchBox [name=\"date\"]").fill("2025-10-01");
       await page.locator("#batchBox button").getByText("Save").click();
-
-      await expect(page.locator("a").getByText(TEST_BATCH_RENAMED, { exact: true })).toHaveCount(1, { timeout: 10000 });
+      await expect(page.getByRole("link", { name: TEST_BATCH_RENAMED, exact: true })).toHaveCount(1, { timeout: 10000 });
       await expect(page.locator("p").getByText("Oct 1, 2025")).toHaveCount(1, { timeout: 10000 });
     });
 
     test("should cancel editing batch", async () => {
       await openBatchesTab(page);
-
-      const row = page.locator("tr").filter({ has: page.locator("a").getByText(TEST_BATCH_RENAMED, { exact: true }) });
-      const editBtn = row.getByRole("button", { name: /Edit/ });
-      await row.scrollIntoViewIfNeeded();
-      await row.hover();
-      await expect(editBtn).toBeVisible({ timeout: 10000 });
-      await editBtn.click({ force: true });
+      const batchLink = page.getByRole("link", { name: TEST_BATCH_RENAMED, exact: true });
+      await expect(batchLink).toBeVisible({ timeout: 10000 });
+      await page.locator("tr", { has: batchLink }).getByRole("button", { name: "Edit" }).click();
       const batchName = page.locator("#batchBox [name=\"name\"]");
       await expect(batchName).toBeVisible({ timeout: 10000 });
       await expect(batchName).toHaveValue(TEST_BATCH_RENAMED, { timeout: 10000 });

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -121,8 +121,8 @@ test.describe.serial("Donations Management", () => {
       await editBtn.click();
       await batchGet;
 
-      const batchName = page.locator('[name="name"]');
-      await expect(batchName).not.toHaveValue("", { timeout: 10000 });
+      const batchName = page.locator("#batchBox [name=\"name\"]");
+      await expect(batchName).toHaveValue(TEST_BATCH_INITIAL, { timeout: 10000 });
       await batchName.fill(TEST_BATCH_RENAMED);
       await page.locator('[name="date"]').fill("2025-10-01");
       await page.locator("button").getByText("Save").click();

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -131,7 +131,7 @@ test.describe.serial("Donations Management", () => {
       const batchName = page.locator("#batchBox [name=\"name\"]");
       await expect(batchName).toBeVisible({ timeout: 10000 });
       await expect(batchName).toHaveValue(TEST_BATCH_RENAMED, { timeout: 10000 });
-      await page.locator("#batchBox button").getByText("Cancel").click();
+      await page.locator("#batchBox button").getByText("Cancel").click({ force: true });
       await expect(batchName).toHaveCount(0, { timeout: 10000 });
     });
 

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -131,7 +131,7 @@ test.describe.serial("Donations Management", () => {
       const batchName = page.locator("#batchBox [name=\"name\"]");
       await expect(batchName).toBeVisible({ timeout: 10000 });
       await expect(batchName).toHaveValue(TEST_BATCH_RENAMED, { timeout: 10000 });
-      await page.locator("#batchBox button").getByText("Cancel").click({ force: true });
+      await page.locator("#batchBox button").getByText("Cancel").evaluate((el: HTMLElement) => el.click());
       await expect(batchName).toHaveCount(0, { timeout: 10000 });
     });
 

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -111,42 +111,37 @@ test.describe.serial("Donations Management", () => {
     test("should edit batch", async () => {
       await openBatchesTab(page);
 
-      const row = page.locator("tr").filter({ has: page.locator("a").getByText(TEST_BATCH_INITIAL) });
+      const row = page.locator("tr").filter({ has: page.locator("a").getByText(TEST_BATCH_INITIAL, { exact: true }) });
       const editBtn = row.getByRole("button", { name: /Edit/ });
+      await row.scrollIntoViewIfNeeded();
+      await row.hover();
       await expect(editBtn).toBeVisible({ timeout: 10000 });
-      const batchGet = page.waitForResponse(
-        r => /\/giving\/donationbatches\/[^/?]+(\?|$)/.test(r.url()) && r.request().method() === "GET",
-        { timeout: 15000 }
-      ).catch((): null => null);
-      await editBtn.click();
-      await batchGet;
+      await editBtn.click({ force: true });
 
       const batchName = page.locator("#batchBox [name=\"name\"]");
+      await expect(batchName).toBeVisible({ timeout: 10000 });
       await expect(batchName).toHaveValue(TEST_BATCH_INITIAL, { timeout: 10000 });
       await batchName.fill(TEST_BATCH_RENAMED);
-      await page.locator('[name="date"]').fill("2025-10-01");
-      await page.locator("button").getByText("Save").click();
+      await page.locator("#batchBox [name=\"date\"]").fill("2025-10-01");
+      await page.locator("#batchBox button").getByText("Save").click();
 
-      await expect(page.locator("a").getByText(TEST_BATCH_RENAMED)).toHaveCount(1, { timeout: 10000 });
+      await expect(page.locator("a").getByText(TEST_BATCH_RENAMED, { exact: true })).toHaveCount(1, { timeout: 10000 });
       await expect(page.locator("p").getByText("Oct 1, 2025")).toHaveCount(1, { timeout: 10000 });
     });
 
     test("should cancel editing batch", async () => {
       await openBatchesTab(page);
 
-      const row = page.locator("tr").filter({ has: page.locator("a").getByText(TEST_BATCH_RENAMED) });
+      const row = page.locator("tr").filter({ has: page.locator("a").getByText(TEST_BATCH_RENAMED, { exact: true }) });
       const editBtn = row.getByRole("button", { name: /Edit/ });
+      await row.scrollIntoViewIfNeeded();
+      await row.hover();
       await expect(editBtn).toBeVisible({ timeout: 10000 });
-      const batchGet = page.waitForResponse(
-        r => /\/giving\/donationbatches\/[^/?]+(\?|$)/.test(r.url()) && r.request().method() === "GET",
-        { timeout: 15000 }
-      ).catch((): null => null);
-      await editBtn.click();
-      await batchGet;
-      const batchName = page.locator('[name="name"]');
+      await editBtn.click({ force: true });
+      const batchName = page.locator("#batchBox [name=\"name\"]");
       await expect(batchName).toBeVisible({ timeout: 10000 });
-      await expect(batchName).not.toHaveValue("", { timeout: 10000 });
-      await page.locator("button").getByText("Cancel").click();
+      await expect(batchName).toHaveValue(TEST_BATCH_RENAMED, { timeout: 10000 });
+      await page.locator("#batchBox button").getByText("Cancel").click();
       await expect(batchName).toHaveCount(0, { timeout: 10000 });
     });
 

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -244,7 +244,7 @@ test.describe.serial("Donations Management", () => {
       const editBtn = page.locator('[data-cy="edit-link-0"]');
       await expect(editBtn).toBeVisible({ timeout: 10000 });
       await editBtn.click();
-      const deleteBtn = page.locator("button").getByText("Delete");
+      const deleteBtn = page.locator('[id="delete"]');
       await expect(deleteBtn).toBeVisible({ timeout: 10000 });
       await deleteBtn.click();
       await confirmDelete(page);

--- a/tests/group-health.spec.ts
+++ b/tests/group-health.spec.ts
@@ -3,7 +3,7 @@ import { groupsTest as test, expect } from "./helpers/test-fixtures";
 import { login } from "./helpers/auth";
 import { navigateToGroups } from "./helpers/navigation";
 import { STORAGE_STATE_PATH } from "./global-setup";
-import { confirmDelete } from "./helpers/fixtures";
+import { confirmDelete, openSeedGroup } from "./helpers/fixtures";
 
 test.describe.serial("Group Health & Calendar", () => {
   let page: Page;
@@ -24,8 +24,7 @@ test.describe.serial("Group Health & Calendar", () => {
   });
 
   const openFirstGroup = async () => {
-    await page.locator("table tbody tr a").first().click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page);
   };
 
   test("groups page links to the health comparison view", async () => {

--- a/tests/group-health.spec.ts
+++ b/tests/group-health.spec.ts
@@ -25,7 +25,7 @@ test.describe.serial("Group Health & Calendar", () => {
 
   const openFirstGroup = async () => {
     await page.locator("table tbody tr a").first().click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
   };
 
   test("groups page links to the health comparison view", async () => {

--- a/tests/group-join-requests.spec.ts
+++ b/tests/group-join-requests.spec.ts
@@ -28,7 +28,7 @@ test.describe.serial("Group Join Requests", () => {
   test("enrollment policy field is present and persists", async () => {
     const firstGroup = page.locator("table tbody tr a").first();
     await firstGroup.click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await page.locator('[data-testid="edit-group-button"]').click();
 
     const select = page.locator('[data-testid="join-policy-select"]');
@@ -40,7 +40,7 @@ test.describe.serial("Group Join Requests", () => {
     await page.locator("#groupDetailsBox button").filter({ hasText: /^save$/i }).first().click();
     await savePost;
     await page.reload();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await page.locator('[data-testid="edit-group-button"]').click();
     await expect(page.locator('[data-testid="join-policy-select"]')).toContainText(/Request to Join/i);
     await page.locator('[data-testid="join-policy-select"]').click();
@@ -53,7 +53,7 @@ test.describe.serial("Group Join Requests", () => {
   test("members tab still renders for a group in request mode", async () => {
     const firstGroup = page.locator("table tbody tr a").first();
     await firstGroup.click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await expect(page.locator("#groupMembersBox")).toBeVisible({ timeout: 10000 });
   });
 

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -220,8 +220,6 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should edit group details", async () => {
-      // Do not rename Sunday Morning Service — later serial tests and parallel
-      // specs (attendance, check-in, campus) still need the seed group.
       await openSeedGroup(page, "Elementary (3-5)");
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
@@ -234,7 +232,6 @@ test.describe.serial("Group Management", () => {
       await saveBtn.click();
       const title = page.locator("#page-header-title");
       await expect(title).toContainText("Elementary (2-5)", { timeout: 10000 });
-      // Restore the seed name so a serial retry can find Elementary (3-5) again.
       await editIconButton(page).click();
       await expect(page.locator('[name="name"]')).toBeVisible({ timeout: 10000 });
       await page.locator('[name="name"]').fill("Elementary (3-5)");

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -447,6 +447,7 @@ test.describe("Group service times (optional) field", () => {
 });
 
 test.describe.serial("Groups — Duplicate, Archive, Restore", () => {
+  test.describe.configure({ retries: 0 });
   let page: Page;
   const SOURCE_GROUP = "Empty Nesters Group";
   const DUPLICATE_NAME = `${SOURCE_GROUP} (Copy)`;
@@ -499,7 +500,7 @@ test.describe.serial("Groups — Duplicate, Archive, Restore", () => {
 
     const toggle = page.locator('[data-testid="show-archived-toggle"] input');
     await toggle.click();
-    await expect(page.locator("table tbody tr a").getByText(DUPLICATE_NAME)).toBeVisible({ timeout: 10000 });
+    await expect(page.locator("table tbody tr a").getByText(DUPLICATE_NAME).first()).toBeVisible({ timeout: 10000 });
   });
 
   test("Restore returns the group to the active (non-archived) list", async () => {
@@ -510,7 +511,7 @@ test.describe.serial("Groups — Duplicate, Archive, Restore", () => {
 
     const toggle = page.locator('[data-testid="show-archived-toggle"] input');
     await toggle.click();
-    await expect(page.locator("table tbody tr a").getByText(DUPLICATE_NAME)).toBeVisible({ timeout: 10000 });
+    await expect(page.locator("table tbody tr a").getByText(DUPLICATE_NAME).first()).toBeVisible({ timeout: 10000 });
   });
 
   test("cleanup: deletes the duplicated group", async () => {

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -40,27 +40,27 @@ test.describe.serial("Group Management", () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
 
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
     });
 
     test("should view person details from group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const firstPerson = page.locator('[id="groupMemberTable"] a').first();
       await firstPerson.click();
-      await page.waitForURL(/\/people\/PER\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/people\/PER\d+/);
+      await page.waitForURL(/\/people\/(?!demographics|lists)[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/people\/(?!demographics|lists)[^/?#]+/);
     });
 
     test("should add person to group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const searchInput = page.locator('input[name="personAddText"]');
       await searchInput.fill("Demo User");
@@ -78,8 +78,8 @@ test.describe.serial("Group Management", () => {
     test("should advanced add people", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const advBtn = page.locator("button").getByText("Advanced");
       await advBtn.click();
@@ -110,8 +110,8 @@ test.describe.serial("Group Management", () => {
     test("should delete advanced add conditions", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const advBtn = page.locator("button").getByText("Advanced");
       await advBtn.click();
@@ -137,8 +137,8 @@ test.describe.serial("Group Management", () => {
     test("should remove person from group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const removeBtn = page.locator('[data-testid^="remove-member-button-"]').last();
       await removeBtn.click();
@@ -150,8 +150,8 @@ test.describe.serial("Group Management", () => {
     test("should toggle member leader status", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const memberTable = page.locator("#groupMemberTable");
       const promoteButtons = memberTable.locator('button[data-testid^="promote-leader-button-"]');
@@ -181,8 +181,8 @@ test.describe.serial("Group Management", () => {
     test("should expose member export link", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const exportLink = page.locator("#groupMembersBox a[download]");
       await expect(exportLink).toHaveCount(1);
@@ -192,8 +192,8 @@ test.describe.serial("Group Management", () => {
     test("should send a message to group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const messageBtn = page.locator('button[aria-label="Email this group"]').first();
       await expect(messageBtn).toBeVisible({ timeout: 10000 });
@@ -215,8 +215,8 @@ test.describe.serial("Group Management", () => {
     test("should show templates above group message sender", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const messageBtn = page.locator('[data-testid="send-message-button"]').first();
       await expect(messageBtn).toBeVisible({ timeout: 10000 });
@@ -230,8 +230,8 @@ test.describe.serial("Group Management", () => {
     test("should cancel editing group details", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const editBtn = editIconButton(page);
       await editBtn.click();
@@ -245,8 +245,8 @@ test.describe.serial("Group Management", () => {
     test("should edit group details", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const editBtn = editIconButton(page);
       await editBtn.click();
@@ -264,8 +264,8 @@ test.describe.serial("Group Management", () => {
     test("should cancel adding session to group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await sessionsBtn.click();
@@ -281,8 +281,8 @@ test.describe.serial("Group Management", () => {
     test("should add session to group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await expect(sessionsBtn).toBeVisible({ timeout: 10000 });
@@ -301,8 +301,8 @@ test.describe.serial("Group Management", () => {
     test("should add person to session", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await sessionsBtn.click();
@@ -326,8 +326,8 @@ test.describe.serial("Group Management", () => {
     test("should remove person from session", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await sessionsBtn.click();
@@ -394,8 +394,8 @@ test.describe.serial("Group Management", () => {
     test("should delete group", async () => {
       const firstGroup = page.locator("table tbody tr a").first();
       await firstGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
-      await expect(page).toHaveURL(/\/groups\/GRP\d+/);
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
 
       const editBtn = editIconButton(page);
       await expect(editBtn).toBeVisible({ timeout: 10000 });
@@ -417,21 +417,21 @@ test.describe("Group communication and roster controls", () => {
   test("group detail page exposes Send Message affordance", async ({ page }) => {
     const firstGroup = page.locator("table tbody tr a").first();
     await firstGroup.click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await expect(page.locator('[data-testid="send-message-button"]')).toBeVisible({ timeout: 10000 });
   });
 
   test("group detail page exposes a roster CSV download link", async ({ page }) => {
     const firstGroup = page.locator("table tbody tr a").first();
     await firstGroup.click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await expect(page.locator('a[download="groupmembers.csv"]')).toBeVisible({ timeout: 10000 });
   });
 
   test("clicking Send Message opens the message composer", async ({ page }) => {
     const firstGroup = page.locator("table tbody tr a").first();
     await firstGroup.click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     await page.locator('[data-testid="send-message-button"]').click();
     await expect(page.locator("#groupMembersBox textarea").first()).toBeVisible({ timeout: 10000 });
   });
@@ -439,7 +439,7 @@ test.describe("Group communication and roster controls", () => {
   test("promotes a group member to leader and back", async ({ page }) => {
     const firstGroup = page.locator("table tbody tr a").first();
     await firstGroup.click();
-    await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     const promoteBtn = page.locator('[data-testid^="promote-leader-button-"]').first();
     if (!(await promoteBtn.isVisible().catch(() => false))) {
@@ -462,7 +462,7 @@ test.describe("Group service times (optional) field", () => {
     const groupLink = page.locator("table tbody tr a").getByText("Women's Bible Study", { exact: true });
     await expect(groupLink).toBeVisible({ timeout: 10000 });
     await groupLink.click();
-    await page.waitForURL(/\/groups\/GRP\w+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 
     await editIconButton(page).first().click();
     const box = page.locator("#groupDetailsBox");
@@ -510,7 +510,7 @@ test.describe.serial("Groups — Duplicate, Archive, Restore", () => {
     const groupLink = page.locator("table tbody tr a").getByText(SOURCE_GROUP, { exact: true });
     await expect(groupLink).toBeVisible({ timeout: 10000 });
     await groupLink.click();
-    await page.waitForURL(/\/groups\/GRP\w+/, { timeout: 10000 });
+    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     const originalUrl = page.url();
 
     const groupPost = page.waitForResponse((r) => r.url().includes("/groups") && r.request().method() === "POST", { timeout: 15000 });

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 import { groupsTest as test, expect } from "./helpers/test-fixtures";
-import { dismissSendInviteIfPresent, editIconButton, confirmDelete } from "./helpers/fixtures";
+import { dismissSendInviteIfPresent, editIconButton, confirmDelete, openSeedGroup } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 import { navigateToGroups } from "./helpers/navigation";
 import { STORAGE_STATE_PATH } from "./global-setup";
@@ -37,18 +37,13 @@ test.describe.serial("Group Management", () => {
 
   test.describe("Groups", () => {
     test("should view group details", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+      await openSeedGroup(page);
       await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
     });
 
     test("should view person details from group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const firstPerson = page.locator('[id="groupMemberTable"] a').first();
       await firstPerson.click();
@@ -57,10 +52,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should add person to group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const searchInput = page.locator('input[name="personAddText"]');
       await searchInput.fill("Demo User");
@@ -76,10 +69,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should advanced add people", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const advBtn = page.locator("button").getByText("Advanced");
       await advBtn.click();
@@ -108,10 +99,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should delete advanced add conditions", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const advBtn = page.locator("button").getByText("Advanced");
       await advBtn.click();
@@ -135,10 +124,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should remove person from group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const removeBtn = page.locator('[data-testid^="remove-member-button-"]').last();
       await removeBtn.click();
@@ -148,10 +135,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should toggle member leader status", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const memberTable = page.locator("#groupMemberTable");
       const promoteButtons = memberTable.locator('button[data-testid^="promote-leader-button-"]');
@@ -179,10 +164,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should expose member export link", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const exportLink = page.locator("#groupMembersBox a[download]");
       await expect(exportLink).toHaveCount(1);
@@ -190,10 +173,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should send a message to group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const messageBtn = page.locator('button[aria-label="Email this group"]').first();
       await expect(messageBtn).toBeVisible({ timeout: 10000 });
@@ -213,10 +194,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should show templates above group message sender", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const messageBtn = page.locator('[data-testid="send-message-button"]').first();
       await expect(messageBtn).toBeVisible({ timeout: 10000 });
@@ -228,10 +207,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should cancel editing group details", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const editBtn = editIconButton(page);
       await editBtn.click();
@@ -243,10 +220,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should edit group details", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const editBtn = editIconButton(page);
       await editBtn.click();
@@ -262,10 +237,8 @@ test.describe.serial("Group Management", () => {
 
   test.describe("Sessions", () => {
     test("should cancel adding session to group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await sessionsBtn.click();
@@ -279,10 +252,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should add session to group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await expect(sessionsBtn).toBeVisible({ timeout: 10000 });
@@ -299,10 +270,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should add person to session", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await sessionsBtn.click();
@@ -324,10 +293,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should remove person from session", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
       await sessionsBtn.click();
@@ -392,10 +359,8 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should delete group", async () => {
-      const firstGroup = page.locator("table tbody tr a").first();
-      await firstGroup.click();
-      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
-      await expect(page).toHaveURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/);
+      await openSeedGroup(page);
+      await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const editBtn = editIconButton(page);
       await expect(editBtn).toBeVisible({ timeout: 10000 });
@@ -415,31 +380,23 @@ test.describe.serial("Group Management", () => {
 
 test.describe("Group communication and roster controls", () => {
   test("group detail page exposes Send Message affordance", async ({ page }) => {
-    const firstGroup = page.locator("table tbody tr a").first();
-    await firstGroup.click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page);
     await expect(page.locator('[data-testid="send-message-button"]')).toBeVisible({ timeout: 10000 });
   });
 
   test("group detail page exposes a roster CSV download link", async ({ page }) => {
-    const firstGroup = page.locator("table tbody tr a").first();
-    await firstGroup.click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page);
     await expect(page.locator('a[download="groupmembers.csv"]')).toBeVisible({ timeout: 10000 });
   });
 
   test("clicking Send Message opens the message composer", async ({ page }) => {
-    const firstGroup = page.locator("table tbody tr a").first();
-    await firstGroup.click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page);
     await page.locator('[data-testid="send-message-button"]').click();
     await expect(page.locator("#groupMembersBox textarea").first()).toBeVisible({ timeout: 10000 });
   });
 
   test("promotes a group member to leader and back", async ({ page }) => {
-    const firstGroup = page.locator("table tbody tr a").first();
-    await firstGroup.click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page);
 
     const promoteBtn = page.locator('[data-testid^="promote-leader-button-"]').first();
     if (!(await promoteBtn.isVisible().catch(() => false))) {

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 import { groupsTest as test, expect } from "./helpers/test-fixtures";
-import { dismissSendInviteIfPresent, editIconButton, confirmDelete, openSeedGroup } from "./helpers/fixtures";
+import { dismissSendInviteIfPresent, editIconButton, confirmDelete, openSeedGroup, SESSION_GROUP } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 import { navigateToGroups } from "./helpers/navigation";
 import { STORAGE_STATE_PATH } from "./global-setup";
@@ -234,12 +234,18 @@ test.describe.serial("Group Management", () => {
       await saveBtn.click();
       const title = page.locator("#page-header-title");
       await expect(title).toContainText("Elementary (2-5)", { timeout: 10000 });
+      // Restore the seed name so a serial retry can find Elementary (3-5) again.
+      await editIconButton(page).click();
+      await expect(page.locator('[name="name"]')).toBeVisible({ timeout: 10000 });
+      await page.locator('[name="name"]').fill("Elementary (3-5)");
+      await page.locator("button").getByText("Save").click();
+      await expect(title).toContainText("Elementary (3-5)", { timeout: 10000 });
     });
   });
 
   test.describe("Sessions", () => {
     test("should cancel adding session to group", async () => {
-      await openSeedGroup(page);
+      await openSeedGroup(page, SESSION_GROUP);
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
@@ -254,7 +260,7 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should add session to group", async () => {
-      await openSeedGroup(page);
+      await openSeedGroup(page, SESSION_GROUP);
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
@@ -272,7 +278,7 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should add person to session", async () => {
-      await openSeedGroup(page);
+      await openSeedGroup(page, SESSION_GROUP);
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");
@@ -295,7 +301,7 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should remove person from session", async () => {
-      await openSeedGroup(page);
+      await openSeedGroup(page, SESSION_GROUP);
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const sessionsBtn = page.locator("button").getByText("Sessions");

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -495,7 +495,7 @@ test.describe.serial("Groups — Duplicate, Archive, Restore", () => {
   });
 
   test('archived group is hidden by default and reappears with "Show archived"', async () => {
-    await navigateToGroups(page);
+    if (!/\/groups\/?(\?|$)/.test(page.url())) await navigateToGroups(page);
     await expect(page.locator("table tbody tr a").getByText(DUPLICATE_NAME)).toHaveCount(0, { timeout: 10000 });
 
     const toggle = page.locator('[data-testid="show-archived-toggle"] input');

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -220,7 +220,9 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should edit group details", async () => {
-      await openSeedGroup(page);
+      // Do not rename Sunday Morning Service — later serial tests and parallel
+      // specs (attendance, check-in, campus) still need the seed group.
+      await openSeedGroup(page, "Elementary (3-5)");
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const editBtn = editIconButton(page);
@@ -359,7 +361,7 @@ test.describe.serial("Group Management", () => {
     });
 
     test("should delete group", async () => {
-      await openSeedGroup(page);
+      await openSeedGroup(page, "Zacchaeus Test Group");
       await expect(page).toHaveURL(/\/groups\/(?!health|pending)[^/?#]+/);
 
       const editBtn = editIconButton(page);
@@ -369,10 +371,7 @@ test.describe.serial("Group Management", () => {
       await deleteBtn.click();
       await confirmDelete(page);
 
-      const deletedGroup = page.locator("table tbody tr a").getByText("Elementary (3-5)");
-      const editedDeletedGroup = page.locator("table tbody tr a").getByText("Elementary (2-5)");
-      const delGroups = deletedGroup.or(editedDeletedGroup);
-      await expect(delGroups).toHaveCount(0, { timeout: 10000 });
+      await expect(page.locator("table tbody tr a").getByText("Zacchaeus Test Group")).toHaveCount(0, { timeout: 10000 });
     });
   });
 
@@ -416,10 +415,7 @@ test.describe("Group communication and roster controls", () => {
 
 test.describe("Group service times (optional) field", () => {
   test("lists available service times and assigns one to a group", async ({ page }) => {
-    const groupLink = page.locator("table tbody tr a").getByText("Women's Bible Study", { exact: true });
-    await expect(groupLink).toBeVisible({ timeout: 10000 });
-    await groupLink.click();
-    await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+    await openSeedGroup(page, "Women's Bible Study");
 
     await editIconButton(page).first().click();
     const box = page.locator("#groupDetailsBox");

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -16,6 +16,16 @@ export const SEED_PEOPLE = {
 
 export type SeedPersonName = (typeof SEED_PEOPLE)[keyof typeof SEED_PEOPLE];
 
+// Seed standard group from Api/tools/dbScripts/membership/demo.sql.
+export const SEED_GROUP = "Sunday Morning Service";
+
+export async function openSeedGroup(page: Page, name = SEED_GROUP) {
+  const link = page.locator("table tbody tr a").filter({ hasText: name }).first();
+  await link.waitFor({ state: "visible", timeout: 10000 });
+  await link.click();
+  await page.waitForURL(/\/groups\/(?!health|pending)[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
+}
+
 // Replaces the brittle `page.locator('table tbody tr').first()` pattern that depends on default sort + prior test mutations.
 export async function openKnownPerson(page: Page, name: SeedPersonName) {
   await navigateToPeople(page);

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -18,6 +18,10 @@ export type SeedPersonName = (typeof SEED_PEOPLE)[keyof typeof SEED_PEOPLE];
 
 // Seed standard group from Api/tools/dbScripts/membership/demo.sql.
 export const SEED_GROUP = "Sunday Morning Service";
+// Members, no seed sessions/visits — used by session attendance tests so
+// auto-select of "most recent past session" does not pick a demo session
+// that already has a roster (Sunday Morning Service has ~10 visits).
+export const SESSION_GROUP = "Prayer Team";
 
 export async function openSeedGroup(page: Page, name = SEED_GROUP) {
   // The groups table is long (30+ demo rows). Playwright's default "visible"

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@playwright/test";
-import { navigateToPeople } from "./navigation";
+import { navigateToPeople, navigateToGroups } from "./navigation";
 
 // Named seed people known to exist in the reset demo database (see
 // Api/tools/dbScripts/membership/demo.sql). Tests should prefer
@@ -23,6 +23,7 @@ export async function openSeedGroup(page: Page, name = SEED_GROUP) {
   // The groups table is long (30+ demo rows). Playwright's default "visible"
   // wait requires the row in the viewport, so filter via the client-side
   // search box and scroll before clicking.
+  if (!/\/groups\/?(\?|$)/.test(page.url())) await navigateToGroups(page);
   const search = page.locator('[data-testid="groups-search"] input');
   await search.waitFor({ state: "visible", timeout: 10000 });
   await search.fill(name);

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -37,7 +37,7 @@ export async function openPersonRow(page: Page, name: SeedPersonName | string) {
   }
   await row.waitFor({ state: "visible", timeout: 10000 });
   await row.click();
-  await page.waitForURL(/\/people\/PER\d+/, { timeout: 10000 });
+  await page.waitForURL(/\/people\/(?!demographics|lists)[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 }
 
 // MUI icon-only button helpers. Matches buttons whose icon SVG carries the

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -20,8 +20,15 @@ export type SeedPersonName = (typeof SEED_PEOPLE)[keyof typeof SEED_PEOPLE];
 export const SEED_GROUP = "Sunday Morning Service";
 
 export async function openSeedGroup(page: Page, name = SEED_GROUP) {
+  // The groups table is long (30+ demo rows). Playwright's default "visible"
+  // wait requires the row in the viewport, so filter via the client-side
+  // search box and scroll before clicking.
+  const search = page.locator('[data-testid="groups-search"] input');
+  await search.waitFor({ state: "visible", timeout: 10000 });
+  await search.fill(name);
   const link = page.locator("table tbody tr a").filter({ hasText: name }).first();
   await link.waitFor({ state: "visible", timeout: 10000 });
+  await link.scrollIntoViewIfNeeded();
   await link.click();
   await page.waitForURL(/\/groups\/(?!health|pending)[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
 }

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -16,17 +16,10 @@ export const SEED_PEOPLE = {
 
 export type SeedPersonName = (typeof SEED_PEOPLE)[keyof typeof SEED_PEOPLE];
 
-// Seed standard group from Api/tools/dbScripts/membership/demo.sql.
 export const SEED_GROUP = "Sunday Morning Service";
-// Members, no seed sessions/visits — used by session attendance tests so
-// auto-select of "most recent past session" does not pick a demo session
-// that already has a roster (Sunday Morning Service has ~10 visits).
 export const SESSION_GROUP = "Prayer Team";
 
 export async function openSeedGroup(page: Page, name = SEED_GROUP) {
-  // The groups table is long (30+ demo rows). Playwright's default "visible"
-  // wait requires the row in the viewport, so filter via the client-side
-  // search box and scroll before clicking.
   if (!/\/groups\/?(\?|$)/.test(page.url())) await navigateToGroups(page);
   const search = page.locator('[data-testid="groups-search"] input');
   await search.waitFor({ state: "visible", timeout: 10000 });

--- a/tests/helpers/navigation.ts
+++ b/tests/helpers/navigation.ts
@@ -86,7 +86,7 @@ export async function openPrimaryNav(page: Page) {
 
 async function clickPrimary(page: Page, section: PrimarySection) {
   await openPrimaryNav(page);
-  const item = page.locator(`[data-testid="nav-item-${section}"]`);
+  const item = page.locator(`[data-testid="nav-item-${section}"][role="button"]`);
   await item.waitFor({ state: "visible", timeout: 10000 });
   await item.click();
   await page.waitForURL(PRIMARY_URL_PATTERNS[section], { timeout: 15000 });

--- a/tests/helpers/navigation.ts
+++ b/tests/helpers/navigation.ts
@@ -86,7 +86,7 @@ export async function openPrimaryNav(page: Page) {
 
 async function clickPrimary(page: Page, section: PrimarySection) {
   await openPrimaryNav(page);
-  const item = page.locator(`[data-testid="nav-item-${section}"][role="button"]`);
+  const item = page.locator(`.MuiListItemButton-root[data-testid="nav-item-${section}"]`);
   await item.waitFor({ state: "visible", timeout: 10000 });
   await item.click();
   await page.waitForURL(PRIMARY_URL_PATTERNS[section], { timeout: 15000 });

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -585,8 +585,6 @@ test.describe("People Management", () => {
       await navigateToPeople(page);
       const searchInput = page.locator('input[name="searchText"]');
       await expect(searchInput).toBeVisible({ timeout: 10000 });
-      // fill() + debounce (500ms) triggers advancedSearch; assert the row, not the XHR,
-      // so a cached list or a missed waiter still fails only if Robert remains.
       await searchInput.fill("Robert Moore");
       const validatedMerge = page.locator("table tbody tr").filter({ hasText: "Robert Moore" });
       await expect(validatedMerge).toHaveCount(0, { timeout: 20000 });

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -12,7 +12,7 @@ test.describe("People Management", () => {
   test.describe("Individuals", () => {
     test("should view person details", async ({ page }) => {
       await openPersonRow(page, SEED_PEOPLE.DONALD);
-      await expect(page).toHaveURL(/\/people\/PER\d+/);
+      await expect(page).toHaveURL(/\/people\/(?!demographics|lists)[^/?#]+/);
     });
 
     test("should search for people", async ({ page }) => {
@@ -49,7 +49,7 @@ test.describe("People Management", () => {
       const donaldRow = page.locator("table tbody tr").filter({ hasText: "Donald Clark" }).first();
       await expect(donaldRow).toBeVisible({ timeout: 10000 });
       await donaldRow.click();
-      await page.waitForURL(/\/people\/PER\d+/, { timeout: 10000 });
+      await page.waitForURL(/\/people\/(?!demographics|lists)[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     });
 
     test("should delete advance search conditions", async ({ page }) => {
@@ -258,7 +258,7 @@ test.describe("People Management", () => {
       const seekGroup = page.locator('ul a[href^="/groups/"]').first();
       await expect(seekGroup).toBeVisible({ timeout: 10000 });
       await seekGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     });
 
     test("should open attendance tab", async ({ page }) => {
@@ -281,7 +281,7 @@ test.describe("People Management", () => {
       const seekGroup = page.locator('table a[href^="/groups/"]').first();
       await expect(seekGroup).toBeVisible({ timeout: 10000 });
       await seekGroup.click();
-      await page.waitForURL(/\/groups\/GRP\d+/, { timeout: 10000 });
+      await page.waitForURL(/\/groups\/(?!health(?:\/|$))[^/?#]+/, { timeout: 10000, waitUntil: "commit" });
     });
 
     test("should open donations tab", async ({ page }) => {
@@ -571,7 +571,7 @@ test.describe("People Management", () => {
       await expect(confirmBtn).toBeVisible({ timeout: 20000 });
       // Wait for DELETE + navigate("/people") after Promise.all resolves.
       const deleteResponse = page.waitForResponse(
-        (response) => response.url().match(/\/people\/PER\d+/) !== null
+        (response) => response.url().match(/\/people\/(?!demographics|lists)[^/?#]+/) !== null
           && response.request().method() === "DELETE"
           && response.status() === 200,
         { timeout: 30000 }
@@ -584,13 +584,10 @@ test.describe("People Management", () => {
       // After merge, one of the two should no longer show in search results.
       await navigateToPeople(page);
       const searchInput = page.locator('input[name="searchText"]');
-      // Register listener before fill (fast response may slip past waiter).
-      const searched = page.waitForResponse(
-        (response) => response.url().includes("/people/advancedSearch") && response.status() === 200,
-        { timeout: 20000 }
-      );
+      await expect(searchInput).toBeVisible({ timeout: 10000 });
+      // fill() + debounce (500ms) triggers advancedSearch; assert the row, not the XHR,
+      // so a cached list or a missed waiter still fails only if Robert remains.
       await searchInput.fill("Robert Moore");
-      await searched;
       const validatedMerge = page.locator("table tbody tr").filter({ hasText: "Robert Moore" });
       await expect(validatedMerge).toHaveCount(0, { timeout: 20000 });
     });

--- a/tests/serving-plans.spec.ts
+++ b/tests/serving-plans.spec.ts
@@ -74,8 +74,7 @@ test.describe.serial("Serving Management - Plans", () => {
       ).catch((): null => null);
       await saveBtn.click();
       await groupPost;
-      const verifiedEdit = page.locator("p").getByText("Zebedee Ministry");
-      await expect(verifiedEdit).toHaveCount(1, { timeout: 15000 });
+      await expect(page.locator("#page-header-title")).toHaveText("Zebedee Ministry", { timeout: 15000 });
     });
 
     test("should cancel editing ministry", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Local Playwright vs B1Admin `:3101` + Api `:8084` (`reset-demo`).

| Spec | Cause | Fix |
|---|---|---|
| campaigns | missing `PageHeaderStats` import | product |
| donations period toggle | Api monthly/quarterly SQL fails `ONLY_FULL_GROUP_BY` | Api (cannot push; patch in agent report) |
| donations delete donation | `Delete` matched icon buttons | test `#delete` |
| donations edit/cancel batch | empty form; editor remounted on list refetch | product + test |
| navigation Dashboard | `nav-item-dashboard` on in-page links | product + test |
| groups / campus / people URLs | shortIds; SPA `waitForURL` | test |
| groups sessions / edit / delete | seed group below fold, renamed, or already has visits | test |
| groups archive | serial retry / extra nav click | test |
| campus city persist | editor kept a stale list row | product + test |
| serving-plans edit | name is `#page-header-title` | test |
| people merge | raced `advancedSearch` | test |
| dashboard people search | name in more than one `<p>` | test |

Latest full run: **521 passed, 2 failed, 1 flaky, 10 skipped, 16 did not run**.

Remaining (not the original 10; appear under 4-worker load):
- `donations` delete fund — Zebedee Fund link still present after delete
- `serving-workflows` group step cards — expected >10, got 10
- people bulk-add (flaky, passed on retry)

LessonsApi on 8090 was not started (optional). Cannot push ChurchApps/Api (403).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bc84be2-6e6d-4c8d-83ba-359ec1921813?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bc84be2-6e6d-4c8d-83ba-359ec1921813&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

