### PR TITLE
Noindex demo.b1.church on the demo deploy only

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
+# Allow all. Demo deploy overwrites dist/robots.txt with Disallow: / (see vite.config.ts). Do not Disallow here — that would noindex admin.b1.church.
 User-agent: *
 Disallow:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,26 @@
-import { defineConfig, loadEnv, type UserConfig } from "vite";
+import { defineConfig, loadEnv, type Plugin, type UserConfig } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
+import fs from "fs";
 import path from "path";
 
+// demo.b1.church is this app (s3://demo-chums-app). Do not noindex prod (admin.b1.church / s3://chums-app).
+function noindexNonProd(stage: string | undefined): Plugin {
+  const noindexMeta = stage === "demo" || stage === "staging";
+  const disallowAll = stage === "demo";
+  return {
+    name: "noindex-nonprod",
+    transformIndexHtml(html) {
+      if (!noindexMeta || html.includes('name="robots"')) return html;
+      return html.replace("<head>", '<head>\n    <meta name="robots" content="noindex, nofollow" />');
+    },
+    closeBundle() {
+      if (!disallowAll) return;
+      fs.writeFileSync(path.resolve("dist/robots.txt"), "User-agent: *\nDisallow: /\n");
+    }
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -13,6 +30,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       babel({ presets: [reactCompilerPreset()] }),
+      noindexNonProd(env.REACT_APP_STAGE),
       // Uploads sourcemaps so Sentry stack traces aren't minified; no-op without the token.
       !!env.SENTRY_AUTH_TOKEN && sentryVitePlugin({
         org: "churchapps",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Investigation

Jeremy asked SEO to stop Google indexing `demo.b1.church`. Search Console (b1.church, last 28 days) shows it as a top page (9 clicks / 309 impressions). ChurchApps/B1App#503 confirmed that host is **this repo**, not B1App.

Live checks (2026-08-16):

| Host | What serves it |
|---|---|
| `demo.b1.church` | This Vite SPA (“B1.church Admin”) on S3/CloudFront. `robots.txt` matches `public/robots.txt` (`Disallow:` = allow all). Deploy: `yarn deploy-demo` → `s3://demo-chums-app`. |
| `admin.b1.church` | Same app, production. Different CloudFront distribution and HTML etag. Deploy: `s3://chums-app`. **Left indexable.** |
| `app.chums.org` | Same production HTML as `admin.b1.church` (legacy Chums URL). **Left indexable.** |
| `staging.b1.church` | Not this app (old ChurchApps marketing CRA). See B1App#503. |

## What this PR changes

Build-time, keyed off `REACT_APP_STAGE` (the same env the deploy scripts already set):

- **demo** (`yarn deploy-demo`): overwrite `dist/robots.txt` with `Disallow: /`, and inject `<meta name="robots" content="noindex, nofollow">` into `index.html`.
- **staging** (`yarn deploy-staging`): meta noindex only. `public/robots.txt` is unchanged (Disallow is demo-only, per request).
- **prod** (`yarn deploy-prod` / `admin.b1.church`): no change to robots or HTML.

`public/robots.txt` stays allow-all so a global Disallow is not applied to every environment.

X-Robots-Tag is not set at CloudFront: demo and prod use different distributions, but this repo has no CloudFront response-headers policy. Google honors the HTML meta tag on the same `index.html` CloudFront already serves for every SPA route.

## Out of scope

- `staging.b1.church` / `staging.churchapps.org` — not this app.
- Production admin hosts (`admin.b1.church`, `app.chums.org`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2266901f-bcad-433e-bdaa-80ebd1038016?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2266901f-bcad-433e-bdaa-80ebd1038016&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

