### PR TITLE
Require current password when changing password

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2498,6 +2498,8 @@
       "lightMode": "Light Mode",
       "linkedAccounts": "Linked Accounts",
       "noDirect": "Hide me from the member directory",
+      "passCurrent": "Current password",
+      "passCurrentMsg": "Please enter your current password.",
       "passLong": "Please enter a password that is at least 8 characters long.",
       "passMatch": "Passwords do not match.",
       "passNew": "New password",

--- a/src/profile/ProfilePage.tsx
+++ b/src/profile/ProfilePage.tsx
@@ -17,6 +17,7 @@ export const ProfilePage = () => {
   const isDemo = process.env.REACT_APP_STAGE === "demo";
   const { mode, toggleTheme } = useThemeMode();
 
+  const [currentPassword, setCurrentPassword] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [passwordVerify, setPasswordVerify] = useState<string>("");
   const [firstName, setFirstName] = useState<string>("");
@@ -45,7 +46,7 @@ export const ProfilePage = () => {
       const promises: Promise<any>[] = [];
 
       if (password.length >= 8) {
-        promises.push(ApiHelper.post("/users/updatePassword", { newPassword: password }, "MembershipApi"));
+        promises.push(ApiHelper.post("/users/updatePassword", { currentPassword, newPassword: password }, "MembershipApi"));
       }
 
       if (areNamesChanged()) {
@@ -63,6 +64,7 @@ export const ProfilePage = () => {
       UserHelper.user.lastName = lastName;
       UserHelper.user.email = email;
       setSaveMessage(Locale.label("profile.profilePage.saveChange"));
+      setCurrentPassword("");
       setPassword("");
       setPasswordVerify("");
       sendEventToReactNative("profile_updated");
@@ -99,6 +101,7 @@ export const ProfilePage = () => {
       case "firstName": setFirstName(val); break;
       case "lastName": setLastName(val); break;
       case "email": setEmail(val); break;
+      case "currentPassword": setCurrentPassword(val); break;
       case "password": setPassword(val); break;
       case "passwordVerify": setPasswordVerify(val); break;
     }
@@ -112,6 +115,7 @@ export const ProfilePage = () => {
       { condition: !lastName, message: Locale.label("profile.profilePage.lastMsg") },
       { condition: email === "", message: Locale.label("profile.profilePage.emailMsg") },
       { condition: email !== "" && !validateEmail(email), message: Locale.label("profile.profilePage.valEmail") },
+      { condition: password !== "" && !currentPassword, message: Locale.label("profile.profilePage.passCurrentMsg", "Please enter your current password.") },
       { condition: password !== passwordVerify, message: Locale.label("profile.profilePage.passMatch") },
       { condition: password !== "" && password.length < 8, message: Locale.label("profile.profilePage.passLong") }
     ];
@@ -175,6 +179,24 @@ export const ProfilePage = () => {
                 <TextField fullWidth name="lastName" label={Locale.label("person.lastName")} value={lastName} onChange={handleChange} placeholder={Locale.label("placeholders.person.lastName")} />
               </Grid>
 
+              <Grid size={{ xs: 12 }}>
+                <TextField
+                  type={showPassword ? "text" : "password"}
+                  fullWidth
+                  name="currentPassword"
+                  label={Locale.label("profile.profilePage.passCurrent", "Current password")}
+                  value={currentPassword}
+                  onChange={handleChange}
+                  disabled={isDemo}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <AppIconButton label={Locale.label("profile.profilePage.togglePasswordVisibility")} icon={showPassword ? <Icon>visibility</Icon> : <Icon>visibility_off</Icon>} onClick={() => setShowPassword(!showPassword)} disabled={isDemo} />
+                      </InputAdornment>
+                    )
+                  }}
+                />
+              </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
                 <TextField
                   type={showPassword ? "text" : "password"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`POST /membership/users/updatePassword` will require `currentPassword` (ChurchApps/Api #69). Profile save currently sends only `{ newPassword }` and will 401 after that merges.

## Change
- Add a current-password field on the profile edit form
- Send `{ currentPassword, newPassword }` when the user changes their password
- Require current password only when a new password is entered

Forgot-password / `setPasswordGuid` reset is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f60a135e-ece5-4543-875f-458d4556c8f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f60a135e-ece5-4543-875f-458d4556c8f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

