### PR TITLE
Stop putting the Transfer JWT in the query string

### DIFF
--- a/src/settings/ManageChurch.tsx
+++ b/src/settings/ManageChurch.tsx
@@ -249,7 +249,7 @@ export const ManageChurch = () => {
             </HeaderSecondaryButton>
           )}
           <HeaderSecondaryButton
-            {...({ href: `https://transfer.b1.church/login?jwt=${jwt}&churchId=${churchId}`, target: "_blank", rel: "noreferrer noopener" } as any)}
+            {...({ href: `https://transfer.b1.church/login?churchId=${churchId}#jwt=${encodeURIComponent(jwt || "")}`, target: "_blank", rel: "noreferrer noopener" } as any)}
             startIcon={<PlayArrowIcon />}>
             {Locale.label("settings.manageChurch.imEx")}
           </HeaderSecondaryButton>

--- a/tests/import-export.spec.ts
+++ b/tests/import-export.spec.ts
@@ -9,10 +9,11 @@ test.describe("Settings — Import/Export entry point", () => {
 
   test("Import/Export button targets transfer.b1.church with auth params", async ({ page }) => {
     const button = page.getByRole("link", { name: "Import/Export" });
-    const href = await button.getAttribute("href");
+    const href = await button.getAttribute("href") || "";
     expect(href).toContain("transfer.b1.church/login");
-    expect(href).toContain("jwt=");
-    expect(href).toContain("churchId=");
+    expect(href).toMatch(/[?&]churchId=/);
+    expect(href).toContain("#jwt=");
+    expect(href).not.toMatch(/[?&]jwt=/);
   });
 
   test("Import/Export button opens in a new tab", async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Settings → Import/Export opened Transfer as `transfer.b1.church/login?jwt=…&churchId=…`. That puts a full-church JWT in the address bar, history, and referrer.

## What we chose
**URL fragment** (`#jwt=`), not a cookie.

Transfer lives on `transfer.b1.church` and Admin on a different host, so a first-party cookie set by Admin would not be sent to Transfer unless we set `Domain=.b1.church`. B1Transfer #16 already prefers `#jwt=`, then cookie, then a one-time leftover `?jwt=` that it immediately strips. No MembershipApi exchange-code protocol.

`churchId` stays in the query. Transfer #16 keeps it there after stripping `jwt`.

Resulting href:

`https://transfer.b1.church/login?churchId={id}#jwt={token}`

The JWT is `encodeURIComponent`'d so Transfer's `URLSearchParams` parse stays correct.

## Test plan
- [ ] Settings → Import/Export href is `transfer.b1.church/login?churchId=…#jwt=…`
- [ ] href has no `?jwt=` / `&jwt=`
- [ ] Button still opens a new tab
- [ ] Transfer SSO from Admin still works with the #16 client (fragment first)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20c5758b-396d-41bf-90eb-454290e79164?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20c5758b-396d-41bf-90eb-454290e79164&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

