### PR TITLE
Use stored household name in the printed directory

### DIFF
--- a/src/people/PrintDirectoryPage.tsx
+++ b/src/people/PrintDirectoryPage.tsx
@@ -2,86 +2,12 @@ import React, { useContext, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Box, CircularProgress, Typography } from "@mui/material";
-import { type PersonInterface } from "@churchapps/helpers";
+import { type HouseholdInterface, type PersonInterface } from "@churchapps/helpers";
 import { Locale, PersonHelper } from "@churchapps/apphelper";
 import UserContext from "../UserContext";
-
-interface DirectoryHousehold {
-  key: string;
-  sortName: string;
-  letter: string;
-  displayName: string;
-  address1?: string;
-  address2?: string;
-  cityStateZip?: string;
-  phone?: string;
-  email?: string;
-  members: PersonInterface[];
-}
+import { buildHouseholds, firstName } from "./buildHouseholds";
 
 const EXCLUDED_STATUSES = new Set(["Inactive", "Visitor"]);
-
-const ageFrom = (birthDate?: string): number => {
-  if (!birthDate) return -1;
-  const d = new Date(birthDate);
-  if (Number.isNaN(d.getTime())) return -1;
-  const ms = Date.now() - d.getTime();
-  return ms / (365.25 * 24 * 60 * 60 * 1000);
-};
-
-const firstName = (p: PersonInterface) => p.name?.nick || p.name?.first || p.name?.display || "";
-
-const buildHouseholds = (people: PersonInterface[]): DirectoryHousehold[] => {
-  const groups = new Map<string, PersonInterface[]>();
-  people.forEach((p) => {
-    const key = p.householdId || `solo-${p.id}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push(p);
-  });
-
-  const households: DirectoryHousehold[] = [];
-  groups.forEach((members, key) => {
-    const sorted = [...members].sort((a, b) => ageFrom(b.birthDate) - ageFrom(a.birthDate));
-    const primary = sorted[0];
-    const lastName = (primary.name?.last || primary.name?.display?.split(" ").pop() || "").trim();
-
-    let displayName: string;
-    if (members.length === 1) {
-      displayName = primary.name?.display || `${firstName(primary)} ${lastName}`.trim();
-    } else if (members.length === 2 && lastName) {
-      displayName = `${firstName(sorted[0])} & ${firstName(sorted[1])} ${lastName}`;
-    } else if (lastName) {
-      displayName = `The ${lastName} Family`;
-    } else {
-      displayName = primary.name?.display || "";
-    }
-
-    const addressSource = members.find((m) => m.contactInfo?.address1) || primary;
-    const ci = addressSource.contactInfo || {};
-    const cityStateZip = [ci.city, ci.state].filter(Boolean).join(", ") + (ci.zip ? ` ${ci.zip}` : "");
-
-    const phoneSource = members.find((m) => m.contactInfo?.homePhone || m.contactInfo?.mobilePhone);
-    const phone = phoneSource?.contactInfo?.homePhone || phoneSource?.contactInfo?.mobilePhone;
-    const emailSource = members.find((m) => m.contactInfo?.email);
-
-    const letter = (lastName[0] || displayName[0] || "#").toUpperCase();
-
-    households.push({
-      key,
-      sortName: (lastName || displayName).toLowerCase(),
-      letter,
-      displayName,
-      address1: ci.address1,
-      address2: ci.address2,
-      cityStateZip: cityStateZip.trim() || undefined,
-      phone,
-      email: emailSource?.contactInfo?.email,
-      members: sorted
-    });
-  });
-
-  return households.sort((a, b) => a.sortName.localeCompare(b.sortName));
-};
 
 const formatDate = (date?: string): string => {
   if (!date) return "";
@@ -120,23 +46,38 @@ export const PrintDirectoryPage = () => {
     placeholderData: []
   });
 
+  const householdRecords = useQuery<HouseholdInterface[]>({
+    queryKey: ["/households", "MembershipApi"],
+    placeholderData: []
+  });
+
+  const householdNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    (householdRecords.data || []).forEach((h) => {
+      if (h.id && h.name?.trim()) map.set(h.id, h.name.trim());
+    });
+    return map;
+  }, [householdRecords.data]);
+
   const households = useMemo(() => {
     if (!people.data) return [];
     const eligible = people.data.filter((p) => !p.optedOut && !EXCLUDED_STATUSES.has(p.membershipStatus || ""));
-    return buildHouseholds(eligible);
-  }, [people.data]);
+    return buildHouseholds(eligible, householdNameById);
+  }, [people.data, householdNameById]);
+
+  const isLoading = people.isLoading || householdRecords.isLoading;
 
   useEffect(() => {
-    if (!people.isLoading && households.length > 0) {
+    if (!isLoading && households.length > 0) {
       const t = setTimeout(() => {
         window.print();
         navigate("/people");
       }, 1500);
       return () => clearTimeout(t);
     }
-  }, [people.isLoading, households.length, navigate]);
+  }, [isLoading, households.length, navigate]);
 
-  if (people.isLoading) {
+  if (isLoading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh" flexDirection="column" gap={2}>
         <CircularProgress />

--- a/src/people/buildHouseholds.ts
+++ b/src/people/buildHouseholds.ts
@@ -1,0 +1,78 @@
+import { type PersonInterface } from "@churchapps/helpers";
+
+export interface DirectoryHousehold {
+  key: string;
+  sortName: string;
+  letter: string;
+  displayName: string;
+  address1?: string;
+  address2?: string;
+  cityStateZip?: string;
+  phone?: string;
+  email?: string;
+  members: PersonInterface[];
+}
+
+const ageFrom = (birthDate?: string): number => {
+  if (!birthDate) return -1;
+  const d = new Date(birthDate);
+  if (Number.isNaN(d.getTime())) return -1;
+  const ms = Date.now() - d.getTime();
+  return ms / (365.25 * 24 * 60 * 60 * 1000);
+};
+
+export const firstName = (p: PersonInterface) => p.name?.nick || p.name?.first || p.name?.display || "";
+
+export const buildHouseholds = (people: PersonInterface[], householdNameById: Map<string, string> = new Map()): DirectoryHousehold[] => {
+  const groups = new Map<string, PersonInterface[]>();
+  people.forEach((p) => {
+    const key = p.householdId || `solo-${p.id}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(p);
+  });
+
+  const households: DirectoryHousehold[] = [];
+  groups.forEach((members, key) => {
+    const sorted = [...members].sort((a, b) => ageFrom(b.birthDate) - ageFrom(a.birthDate));
+    const storedName = (householdNameById.get(key) || "").trim();
+    const surnameSource = storedName ? sorted[0] : (members.find((m) => m.householdRole === "Head") || sorted[0]);
+    const primary = sorted[0];
+    const lastName = storedName || (surnameSource.name?.last || surnameSource.name?.display?.split(" ").pop() || "").trim();
+
+    let displayName: string;
+    if (members.length === 1) {
+      displayName = primary.name?.display || `${firstName(primary)} ${lastName}`.trim();
+    } else if (members.length === 2 && lastName) {
+      displayName = `${firstName(sorted[0])} & ${firstName(sorted[1])} ${lastName}`;
+    } else if (lastName) {
+      displayName = `The ${lastName} Family`;
+    } else {
+      displayName = primary.name?.display || "";
+    }
+
+    const addressSource = members.find((m) => m.contactInfo?.address1) || primary;
+    const ci = addressSource.contactInfo || {};
+    const cityStateZip = [ci.city, ci.state].filter(Boolean).join(", ") + (ci.zip ? ` ${ci.zip}` : "");
+
+    const phoneSource = members.find((m) => m.contactInfo?.homePhone || m.contactInfo?.mobilePhone);
+    const phone = phoneSource?.contactInfo?.homePhone || phoneSource?.contactInfo?.mobilePhone;
+    const emailSource = members.find((m) => m.contactInfo?.email);
+
+    const letter = (lastName[0] || displayName[0] || "#").toUpperCase();
+
+    households.push({
+      key,
+      sortName: (lastName || displayName).toLowerCase(),
+      letter,
+      displayName,
+      address1: ci.address1,
+      address2: ci.address2,
+      cityStateZip: cityStateZip.trim() || undefined,
+      phone,
+      email: emailSource?.contactInfo?.email,
+      members: sorted
+    });
+  });
+
+  return households.sort((a, b) => a.sortName.localeCompare(b.sortName));
+};

--- a/tests/issue-983.spec.ts
+++ b/tests/issue-983.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { peopleTest } from "./helpers/test-fixtures";
+import { type PersonInterface } from "@churchapps/helpers";
+import { buildHouseholds } from "../src/people/buildHouseholds";
+
+const person = (opts: { id: string; first: string; last: string; householdId?: string; householdRole?: string; birthDate?: string; membershipStatus?: string }): PersonInterface => ({
+  id: opts.id,
+  householdId: opts.householdId,
+  householdRole: opts.householdRole,
+  birthDate: opts.birthDate,
+  membershipStatus: opts.membershipStatus || "Member",
+  name: { first: opts.first, last: opts.last, display: `${opts.first} ${opts.last}` },
+  contactInfo: {}
+});
+
+const blendedFamily = () => [
+  person({ id: "p-abe", first: "Alex", last: "Abrahams", householdId: "h-blend" }),
+  person({ id: "p-pat", first: "Pat", last: "Crouch", householdId: "h-blend", householdRole: "Head" }),
+  person({ id: "p-sam", first: "Sam", last: "Crouch", householdId: "h-blend" })
+];
+
+test.describe("Issue 983: print directory household names", () => {
+  test("uses the stored household name for a blended family", () => {
+    const result = buildHouseholds(blendedFamily(), new Map([["h-blend", "Crouch"]]));
+    expect(result).toHaveLength(1);
+    expect(result[0].displayName).toBe("The Crouch Family");
+    expect(result[0].sortName).toBe("crouch");
+    expect(result[0].letter).toBe("C");
+  });
+
+  test("does not pick the alphabetically-first surname when a stored name exists", () => {
+    const people = [
+      person({ id: "p-abe", first: "Alex", last: "Abrahams", householdId: "h-blend" }),
+      person({ id: "p-pat", first: "Pat", last: "Crouch", householdId: "h-blend" }),
+      person({ id: "p-sam", first: "Sam", last: "Crouch", householdId: "h-blend" })
+    ];
+    const withoutStored = buildHouseholds(people);
+    expect(withoutStored[0].displayName).toBe("The Abrahams Family");
+
+    const withStored = buildHouseholds(people, new Map([["h-blend", "Crouch"]]));
+    expect(withStored[0].displayName).toBe("The Crouch Family");
+  });
+
+  test("falls back to the Head member surname when the stored name is blank", () => {
+    const result = buildHouseholds(blendedFamily(), new Map([["h-blend", "   "]]));
+    expect(result[0].displayName).toBe("The Crouch Family");
+  });
+
+  test("falls back to the oldest-member surname when there is no Head and no stored name", () => {
+    const people = [
+      person({ id: "1", first: "Alex", last: "Abrahams", householdId: "h1", birthDate: "2010-01-01" }),
+      person({ id: "2", first: "Pat", last: "Crouch", householdId: "h1", birthDate: "1975-01-01" })
+    ];
+    const result = buildHouseholds(people);
+    expect(result[0].displayName).toBe("Pat & Alex Crouch");
+  });
+
+  test("uses a solo person's own name when householdId is missing", () => {
+    const people = [person({ id: "solo1", first: "Jamie", last: "Solo" })];
+    const result = buildHouseholds(people, new Map([["other", "Crouch"]]));
+    expect(result).toHaveLength(1);
+    expect(result[0].displayName).toBe("Jamie Solo");
+  });
+});
+
+peopleTest.describe("Issue 983: print directory page", () => {
+  peopleTest("renders the stored household name on the print directory", async ({ page }) => {
+    await page.addInitScript(() => { window.print = () => {}; });
+
+    const people = blendedFamily();
+    await page.route("**/membership/people", async (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      const url = route.request().url();
+      if (/\/people\/.+/.test(url)) return route.continue();
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(people) });
+    });
+    await page.route("**/membership/households", async (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      const url = route.request().url();
+      if (/\/households\/.+/.test(url)) return route.continue();
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{ id: "h-blend", name: "Crouch" }]) });
+    });
+
+    await page.goto("/people/print-directory");
+    await expect(page.locator(".household-name")).toContainText("The Crouch Family", { timeout: 15000 });
+    await expect(page.locator(".household-name")).not.toContainText("Abrahams");
+  });
+});


### PR DESCRIPTION
## Summary
- Print Directory now loads `GET /households` (MembershipApi) and uses the stored `household.name` as the surname for each card.
- The previous oldest-member / alphabetical heuristic is kept only as a fallback when there is no `householdId` or the stored name is blank; fallback prefers `householdRole === "Head"` when present.
- Adds `tests/issue-983.spec.ts` covering the blended-family case (would fail before this change) plus helper unit tests.

Fixes ChurchApps/ChurchAppsSupport#983

## Test plan
- [ ] Unit: `buildHouseholds` uses stored name "Crouch" for a blended Abrahams/Crouch household with missing birthdates
- [ ] Unit: blank stored name falls back to Head surname; no Head falls back to oldest member
- [ ] Unit: people without `householdId` still use their own name
- [ ] Playwright (demo env): print directory shows "The Crouch Family" when households API returns that name
- [ ] Do not run against ENVIRONMENT=dev with reset-demo