### PR TITLE
Add Reports to the B1 Admin section menu

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -47,6 +47,7 @@ export const Header: React.FC = () => {
     if (UserHelper.checkAccess(Permissions.contentApi.content.edit)) menuItems.push({ url: "/site/pages", label: Locale.label("common.website"), icon: "language" });
     if (UserHelper.checkAccess(Permissions.contentApi.content.edit)) menuItems.push({ url: "/calendars", label: Locale.label("helpers.secondaryMenuHelper.calendars"), icon: "calendar_month" });
     if (UserHelper.checkAccess(Permissions.contentApi.content.edit)) menuItems.push({ url: "/mobile", label: Locale.label("common.mobile"), icon: "phone_iphone" });
+    menuItems.push({ url: "/reports", label: Locale.label("reports.reportsPage.reports"), icon: "bar_chart" });
 
     if (UserHelper.checkAccess(Permissions.membershipApi.settings.edit)) menuItems.push({ url: "/settings", label: Locale.label("components.wrapper.set"), icon: "settings" });
     else if (UserHelper.checkAccess(Permissions.membershipApi.roles.view)) menuItems.push({ url: "/settings/roles", label: Locale.label("components.wrapper.set"), icon: "settings" });
@@ -75,6 +76,7 @@ export const Header: React.FC = () => {
     else if (path.startsWith("/calendars") || path.startsWith("/registrations")) result = Locale.label("helpers.secondaryMenuHelper.calendars");
     else if (path.startsWith("/site")) result = Locale.label("common.website");
     else if (path.startsWith("/mobile")) result = Locale.label("common.mobile");
+    else if (path.startsWith("/reports")) result = Locale.label("reports.reportsPage.reports");
     else if (path.startsWith("/settings") || path.startsWith("/admin")) result = Locale.label("components.wrapper.set");
     else if (path.startsWith("/dashboard")) result = Locale.label("dashboard.dashboardPage.dash");
     return result;
@@ -110,7 +112,8 @@ export const Header: React.FC = () => {
         "/mobile": "nav-item-mobile",
         "/site/pages": "nav-item-website",
         "/calendars": "nav-item-calendars",
-        "/sermons": "nav-item-sermons"
+        "/sermons": "nav-item-sermons",
+        "/reports": "nav-item-reports"
       };
 
       const scopes = document.querySelectorAll("header, .MuiDrawer-root");
@@ -142,7 +145,8 @@ export const Header: React.FC = () => {
             devices: "nav-item-devices",
             mobile: "nav-item-mobile",
             website: "nav-item-website",
-            sermons: "nav-item-sermons"
+            sermons: "nav-item-sermons",
+            reports: "nav-item-reports"
           };
 
           for (const [key, testId] of Object.entries(textToTestId)) {

--- a/src/helpers/SecondaryMenuHelper.ts
+++ b/src/helpers/SecondaryMenuHelper.ts
@@ -19,6 +19,7 @@ export class SecondaryMenuHelper {
     else if (path.startsWith("/calendars") || path.startsWith("/registrations")) result = this.getCalendarMenu(path);
     else if (path.startsWith("/site")) result = this.getSiteMenu(path);
     else if (path.startsWith("/sermons")) result = this.getSermonsMenu(path);
+    else if (path.startsWith("/reports")) result = this.getReportsMenu(path);
     else if (path.startsWith("/profile")) result = this.getProfileMenu(path);
     else if (path === "/" || path.startsWith("/dashboard")) result = this.getDashboardMenu();
     return result;
@@ -185,6 +186,26 @@ export class SecondaryMenuHelper {
     if (path.startsWith("/sermons/bulk")) label = Locale.label("helpers.secondaryMenuHelper.bulkImport");
     else if (path.startsWith("/sermons/times")) label = Locale.label("helpers.secondaryMenuHelper.liveStreamTimes");
     else if (path.startsWith("/sermons")) label = Locale.label("helpers.secondaryMenuHelper.sermons");
+
+    return { menuItems, label };
+  };
+
+  static getReportsMenu = (path: string) => {
+    const menuItems: MenuItem[] = [];
+    let label: string = Locale.label("reports.reportsPage.reports");
+    menuItems.push({ url: "/reports", label: Locale.label("reports.reportsPage.reports"), icon: "bar_chart" });
+    menuItems.push({ url: "/reports/birthdays", label: Locale.label("reports.reportsPage.bDays"), icon: "cake" });
+    menuItems.push({ url: "/reports/attendanceTrend", label: Locale.label("reports.reportsPage.attTrend"), icon: "trending_up" });
+    menuItems.push({ url: "/reports/groupAttendance", label: Locale.label("reports.reportsPage.groupAtt"), icon: "groups" });
+    menuItems.push({ url: "/reports/dailyGroupAttendance", label: Locale.label("reports.reportsPage.dailyGroupAtt"), icon: "today" });
+    menuItems.push({ url: "/reports/donationSummary", label: Locale.label("reports.reportsPage.donSum"), icon: "volunteer_activism" });
+
+    if (path.startsWith("/reports/birthdays")) label = Locale.label("reports.reportsPage.bDays");
+    else if (path.startsWith("/reports/attendanceTrend")) label = Locale.label("reports.reportsPage.attTrend");
+    else if (path.startsWith("/reports/groupAttendance")) label = Locale.label("reports.reportsPage.groupAtt");
+    else if (path.startsWith("/reports/dailyGroupAttendance")) label = Locale.label("reports.reportsPage.dailyGroupAtt");
+    else if (path.startsWith("/reports/donationSummary")) label = Locale.label("reports.reportsPage.donSum");
+    else if (path.startsWith("/reports")) label = Locale.label("reports.reportsPage.reports");
 
     return { menuItems, label };
   };

--- a/tests/helpers/navigation.ts
+++ b/tests/helpers/navigation.ts
@@ -10,6 +10,7 @@ type PrimarySection =
   | "website"
   | "calendars"
   | "mobile"
+  | "reports"
   | "settings";
 
 // Secondary nav items: only visible after navigating to a parent section.
@@ -47,6 +48,7 @@ const PRIMARY_URL_PATTERNS: Record<PrimarySection, RegExp> = {
   website: /\/site\/pages/,
   calendars: /\/calendars(?!\/)/,
   mobile: /\/mobile/,
+  reports: /\/reports/,
   settings: /\/settings/
 };
 

--- a/tests/issue-992.spec.ts
+++ b/tests/issue-992.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { loggedInTest } from "./helpers/test-fixtures";
+import { openPrimaryNav } from "./helpers/navigation";
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test.describe("Issue 992: Reports nav wiring", () => {
+  test("primary menu includes a /reports entry", () => {
+    const src = readFileSync(path.join(root, "src/components/Header.tsx"), "utf8");
+    expect(src).toMatch(/menuItems\.push\(\{\s*url:\s*"\/reports"/);
+    expect(src).toMatch(/path\.startsWith\("\/reports"\)/);
+    expect(src).toMatch(/"\/reports":\s*"nav-item-reports"/);
+  });
+
+  test("secondary menu for /reports lists the landing page and each report", () => {
+    const src = readFileSync(path.join(root, "src/helpers/SecondaryMenuHelper.ts"), "utf8");
+    expect(src).toContain('path.startsWith("/reports")) result = this.getReportsMenu(path)');
+    const method = src.slice(src.indexOf("static getReportsMenu"));
+    const urls = [...method.matchAll(/url:\s*"([^"]+)"/g)].map((match) => match[1]);
+    expect(urls).toEqual([
+      "/reports",
+      "/reports/birthdays",
+      "/reports/attendanceTrend",
+      "/reports/groupAttendance",
+      "/reports/dailyGroupAttendance",
+      "/reports/donationSummary"
+    ]);
+  });
+});
+
+loggedInTest.describe("Issue 992: Reports in primary navigation", () => {
+  loggedInTest("shows Reports in the section menu and opens /reports", async ({ page }) => {
+    await openPrimaryNav(page);
+    const reports = page.locator('[data-testid="nav-item-reports"]');
+    await expect(reports).toBeVisible({ timeout: 10000 });
+    await reports.click();
+    await expect(page).toHaveURL(/\/reports/);
+    await page.screenshot({ path: "test-results/issue-992-nav.png" });
+  });
+});


### PR DESCRIPTION
## Summary
- Link the existing `/reports` page from the primary section menu (Dashboard, People, Donations, etc.) so staff can find Birthday Report and the other reports without typing the URL.
- Add a Reports secondary menu using the same `SecondaryMenuHelper` pattern as other sections, plus Playwright coverage for issue ChurchAppsSupport#992.

## Test plan
- [ ] Open the B1 Admin hamburger/section menu and confirm **Reports** is listed with Dashboard/People/etc.
- [ ] Click Reports and land on `/reports` (Birthdays, Attendance Trend, Group Attendance, Daily Group Attendance, Donation Summary).
- [ ] Open an individual report and confirm the secondary menu can jump between reports.
- [ ] `npx playwright test tests/issue-992.spec.ts` (unit wiring tests run without demo; the logged-in nav spec needs the usual local Api + B1Admin stack).