### PR TITLE
Honor church firstDayOfWeek on admin calendar grids

### DIFF
--- a/src/calendars/AvailabilityPage.tsx
+++ b/src/calendars/AvailabilityPage.tsx
@@ -6,7 +6,7 @@ import { ApiHelper, UserHelper, EventHelper, Loading, PageHeader, Locale } from 
 import { Permissions } from "@churchapps/helpers";
 import { Box, MenuItem, Stack, TextField } from "@mui/material";
 import { Add as AddIcon, EventAvailable as AvailabilityIcon } from "@mui/icons-material";
-import { useRequirePermission } from "../hooks";
+import { useRequirePermission, useFirstDayOfWeek, applyWeekStart } from "../hooks";
 import { EventModal } from "./components/EventModal";
 import { HeaderPrimaryButton } from "../components/ui/headerButtons";
 import { type CalendarBlockoutInterface, type EventBookingInterface, type ResourceInterface, type RoomInterface } from "./interfaces";
@@ -24,7 +24,12 @@ export const AvailabilityPage = () => {
   const [loading, setLoading] = useState(true);
   const denied = useRequirePermission(Permissions.contentApi.content.edit);
 
-  const localizer = dayjsLocalizer(dayjs);
+  const firstDayOfWeek = useFirstDayOfWeek();
+
+  const localizer = useMemo(() => {
+    applyWeekStart(firstDayOfWeek);
+    return dayjsLocalizer(dayjs);
+  }, [firstDayOfWeek]);
 
   const loadBookings = useCallback(() => {
     setLoading(true);

--- a/src/calendars/components/CuratedEventCalendar.tsx
+++ b/src/calendars/components/CuratedEventCalendar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import dayjs from "dayjs";
 import { Calendar, dayjsLocalizer } from "react-big-calendar";
@@ -10,6 +10,7 @@ import { type CuratedEventWithEventInterface } from "@churchapps/helpers";
 import { EditCalendarEventModal } from "./EditCalendarEventModal";
 import { DisplayCalendarEventModal } from "./DisplayCalendarEventModal";
 import { EnvironmentHelper } from "../../helpers/EnvironmentHelper";
+import { useFirstDayOfWeek, applyWeekStart } from "../../hooks";
 
 interface Props {
   events: CuratedEventWithEventInterface[];
@@ -26,7 +27,12 @@ export function CuratedEventCalendar(props: Props) {
   const [showCopy, setShowCopy] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const localizer = dayjsLocalizer(dayjs);
+  const firstDayOfWeek = useFirstDayOfWeek();
+
+  const localizer = useMemo(() => {
+    applyWeekStart(firstDayOfWeek);
+    return dayjsLocalizer(dayjs);
+  }, [firstDayOfWeek]);
 
   const getIcsUrl = () => {
     const contentApi = EnvironmentHelper.Common.ContentApi;
@@ -140,7 +146,7 @@ export function CuratedEventCalendar(props: Props) {
         onSelectEvent={handleEventClick}
       />
       {open && props.mode === "edit" && (
-        <EditCalendarEventModal onDone={handleDone} churchId={props.churchId || ""} curatedCalendarId={props.curatedCalendarId || ""} />
+        <EditCalendarEventModal onDone={handleDone} churchId={props.churchId || ""} curatedCalendarId={props.curatedCalendarId || ""} firstDayOfWeek={firstDayOfWeek} />
       )}
       {displayCalendarEvent && (
         <DisplayCalendarEventModal event={displayCalendarEvent} curatedCalendarId={props.curatedCalendarId} mode={props.mode} onDone={handleDone} />

--- a/src/calendars/components/EditCalendarEventModal.tsx
+++ b/src/calendars/components/EditCalendarEventModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import dayjs from "dayjs";
 import { Calendar, dayjsLocalizer } from "react-big-calendar";
 import "react-big-calendar/lib/css/react-big-calendar.css";
@@ -24,10 +24,12 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import { Loading, EventHelper, ApiHelper, Locale } from "@churchapps/apphelper";
 import { type GroupInterface, type EventInterface } from "@churchapps/helpers";
+import { applyWeekStart } from "../../hooks";
 
 interface Props {
   churchId: string;
   curatedCalendarId: string;
+  firstDayOfWeek?: number;
   onDone?: () => void;
 }
 
@@ -39,7 +41,10 @@ export function EditCalendarEventModal(props: Props) {
   const [groupEvents, setGroupEvents] = useState<EventInterface[]>([]);
   const [eventIdsList, setEventIdsList] = useState<string[]>([]);
 
-  const localizer = dayjsLocalizer(dayjs);
+  const localizer = useMemo(() => {
+    applyWeekStart(props.firstDayOfWeek);
+    return dayjsLocalizer(dayjs);
+  }, [props.firstDayOfWeek]);
 
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down(396));

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,7 @@ export { useCampuses } from "./useCampuses";
 export { useConfirmDelete } from "./useConfirmDelete";
 export { useSortableData } from "./useSortableData";
 export { useErrorSummary } from "./useErrorSummary";
+export { useFirstDayOfWeek, applyWeekStart } from "./useFirstDayOfWeek";
 export { useReorderableLinks } from "./useReorderableLinks";
 export { useRequirePermission } from "./useRequirePermission";
 export { usePendingApprovalsCount, usePendingJoinRequestsCount } from "./usePendingCounts";

--- a/src/hooks/useFirstDayOfWeek.ts
+++ b/src/hooks/useFirstDayOfWeek.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import updateLocale from "dayjs/plugin/updateLocale";
+import { ApiHelper, UserHelper } from "@churchapps/apphelper";
+
+dayjs.extend(updateLocale);
+
+const clamp = (value: any) => {
+  const day = Math.trunc(Number(value));
+  return day >= 0 && day <= 6 ? day : 0;
+};
+
+// Sets the dayjs week start; call before constructing a dayjsLocalizer.
+export const applyWeekStart = (firstDayOfWeek: any) => {
+  dayjs.updateLocale("en", { weekStart: clamp(firstDayOfWeek) });
+};
+
+// Login omits firstDayOfWeek from the church payload, so fall back to the full church record.
+export const useFirstDayOfWeek = (): number => {
+  const church: any = UserHelper.currentUserChurch?.church;
+  const churchId = church?.id;
+  const query = useQuery<any>({
+    queryKey: [`/churches/${churchId}?include=permissions`, "MembershipApi"],
+    enabled: ApiHelper.isAuthenticated && !!churchId && church?.firstDayOfWeek === undefined
+  });
+  return clamp(church?.firstDayOfWeek ?? query.data?.firstDayOfWeek);
+};


### PR DESCRIPTION
## Summary
- Apply `church.firstDayOfWeek` (0=Sunday … 6=Saturday) to B1Admin availability and curated calendar grids via `dayjs.updateLocale` before `dayjsLocalizer`.
- Login church payload omits the column, so `useFirstDayOfWeek` reads `UserHelper.currentUserChurch.church.firstDayOfWeek` when present and otherwise uses the existing `/churches/:id?include=permissions` MembershipApi query (same key as Roles/ManageChurch).
- ChurchAppsSupport #985. Settings UI already shipped in #448. No GenericSetting `weekStart`.

## Test plan
- [ ] Set First Day of Week in Church Settings, then open Availability and a curated calendar — week headers should match.
- [ ] Anonymous curated calendar view stays Sunday-start (no authenticated church fetch).
- [ ] Invalid / missing values fall back to Sunday.