### PR TITLE
Honor plan customizations in lesson print formats

### DIFF
--- a/src/serving/components/planItemUtils.ts
+++ b/src/serving/components/planItemUtils.ts
@@ -1,6 +1,6 @@
 import { type InstructionItem, type Instructions, type IProvider } from "@churchapps/content-providers";
 import { ApiHelper } from "@churchapps/apphelper";
-import { type PlanItemInterface } from "../../helpers";
+import { type PlanItemInterface, type FeedVenueInterface, type FeedSectionInterface, type FeedActionInterface } from "../../helpers";
 
 /** Gets instructions from a provider based on its capabilities, proxying through the API when auth is required. */
 export async function getProviderInstructions(provider: IProvider, path: string, ministryId?: string, providerId?: string): Promise<Instructions | null> {
@@ -245,4 +245,52 @@ export function isFileType(itemType: string | undefined): boolean {
 
 export function isSongType(itemType: string | undefined): boolean {
   return ["song", "arrangementKey"].includes(itemType || "");
+}
+
+const SECTION_PLAN_TYPES = new Set(["section", "providerSection", "lessonSection", "header"]);
+
+function flattenPlanItems(items: PlanItemInterface[]): PlanItemInterface[] {
+  let result: PlanItemInterface[] = [];
+  items.forEach(item => {
+    result.push(item);
+    if (item.children) result = result.concat(flattenPlanItems(item.children));
+  });
+  return result;
+}
+
+/**
+ * Reconciles pristine lesson/provider content against the (possibly customized) plan items, so
+ * every print format matches the Service Order. Sections still in the plan print in full;
+ * sections expanded into actions keep only the actions that survived; anything else is dropped.
+ */
+export function filterFeedByPlanItems(feed: FeedVenueInterface | null, planItems: PlanItemInterface[]): FeedVenueInterface | null {
+  if (!feed?.sections?.length || !planItems?.length) return feed;
+
+  const norm = (s?: string) => (s || "").trim().toLowerCase();
+  const flat = flattenPlanItems(planItems);
+
+  const sectionItems = flat.filter(pi => SECTION_PLAN_TYPES.has(pi.itemType || ""));
+  const sectionIds = new Set(sectionItems.map(pi => pi.relatedId).filter(Boolean));
+  const sectionNames = new Set(sectionItems.map(pi => norm(pi.label || pi.description)).filter(Boolean));
+
+  const actionItems = flat.filter(pi => !SECTION_PLAN_TYPES.has(pi.itemType || ""));
+  const actionIds = new Set(actionItems.map(pi => pi.relatedId).filter(Boolean));
+  const actionNames = new Set(actionItems
+    .filter(pi => pi.providerId || pi.relatedId)
+    .map(pi => norm(pi.label || pi.description))
+    .filter(Boolean));
+
+  const sectionInPlan = (s: FeedSectionInterface) => (!!s.id && sectionIds.has(s.id)) || sectionNames.has(norm(s.name));
+
+  const sections = feed.sections
+    .map((s: FeedSectionInterface) => {
+      if (sectionInPlan(s)) return s;
+      // id-less actions fall back to exact normalized name match — plan-global, so scope
+      // per-section if duplicate action text ever misprints.
+      const actions = (s.actions || []).filter((a: FeedActionInterface) => (a.id ? actionIds.has(a.id) : !!a.content && actionNames.has(norm(a.content))));
+      return { ...s, actions };
+    })
+    .filter((s: FeedSectionInterface) => sectionInPlan(s) || !!s.actions?.length);
+
+  return { ...feed, sections };
 }

--- a/src/serving/plans/PrintPlan.tsx
+++ b/src/serving/plans/PrintPlan.tsx
@@ -8,7 +8,7 @@ import { type PlanItemTimeInterface, type AssignmentInterface, type PlanInterfac
 import { OlfPrintPreview } from "../components/print/OlfPrintPreview";
 import { type FeedVenueInterface, type FeedSectionInterface, type FeedActionInterface } from "../../helpers";
 import { getProvider, type InstructionItem, type Instructions } from "@churchapps/content-providers";
-import { getProviderInstructions } from "../components/planItemUtils";
+import { getProviderInstructions, filterFeedByPlanItems } from "../components/planItemUtils";
 
 export const PrintPlan = () => {
   const params = useParams();
@@ -170,33 +170,7 @@ export const PrintPlan = () => {
       }
     }
 
-    // Sections still present in the plan print as-is; sections expanded to
-    // individual actions keep only the actions still present in the plan.
-    if (currentFeed?.sections) {
-      const norm = (s?: string) => (s || "").trim().toLowerCase();
-      const planActionIds = new Set(flatPlanItems.map(pi => pi.relatedId).filter(Boolean));
-      const providerItemNames = new Set(flatPlanItems
-        .filter(pi => pi.providerId || pi.relatedId)
-        .map(pi => norm(pi.label || pi.description))
-        .filter(Boolean));
-
-      const sectionItems = flatPlanItems.filter(pi => ["section", "providerSection", "lessonSection", "header"].includes(pi.itemType));
-      const sectionIdsInPlan = new Set(sectionItems.map(pi => pi.relatedId).filter(Boolean));
-      const sectionNamesInPlan = new Set(sectionItems.map(pi => norm(pi.label || pi.description)).filter(Boolean));
-      const sectionInPlan = (s: FeedSectionInterface) => (!!s.id && sectionIdsInPlan.has(s.id)) || sectionNamesInPlan.has(norm(s.name));
-
-      currentFeed.sections.forEach((s: FeedSectionInterface) => {
-        if (sectionInPlan(s)) return;
-        s.actions = (s.actions || []).filter((a: FeedActionInterface) => {
-          if (a.id) return planActionIds.has(a.id);
-          // ponytail: id-less actions fall back to exact normalized name match — still
-          // plan-global; scope per-section if duplicate action text misprints in practice.
-          return !!a.content && providerItemNames.has(norm(a.content));
-        });
-      });
-
-      currentFeed.sections = currentFeed.sections.filter((s: FeedSectionInterface) => sectionInPlan(s) || (s.actions && s.actions.length > 0));
-    }
+    currentFeed = filterFeedByPlanItems(currentFeed, planItemsData || []);
 
     setFeed(currentFeed);
 

--- a/tests/issue-979.spec.ts
+++ b/tests/issue-979.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+import * as esbuild from "esbuild";
+import { type FeedVenueInterface, type PlanItemInterface } from "../src/helpers";
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// planItemUtils pulls in apphelper, which node can't resolve unbundled, so bundle the
+// module under test with its imports stubbed and load it from memory.
+let filterFeedByPlanItems: (feed: FeedVenueInterface | null, planItems: PlanItemInterface[]) => FeedVenueInterface | null;
+
+test.beforeAll(async () => {
+  const built = await esbuild.build({
+    entryPoints: [path.join(root, "src/serving/components/planItemUtils.ts")],
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "neutral",
+    plugins: [
+      {
+        name: "stub-imports",
+        setup(build) {
+          build.onResolve({ filter: /.*/ }, (args) => (args.kind === "entry-point" ? undefined : { path: args.path, namespace: "stub" }));
+          build.onLoad({ filter: /.*/, namespace: "stub" }, () => ({ contents: "export const ApiHelper = {};", loader: "js" }));
+        }
+      }
+    ]
+  });
+  const code = built.outputFiles[0].text;
+  const mod = await import("data:text/javascript;base64," + Buffer.from(code).toString("base64"));
+  filterFeedByPlanItems = mod.filterFeedByPlanItems;
+});
+
+const lessonFeed = (): FeedVenueInterface => ({
+  id: "v1",
+  lessonId: "l1",
+  lessonName: "Sample Lesson",
+  sections: [
+    { id: "s1", name: "Welcome", actions: [{ id: "a1", content: "Greet the kids" }, { id: "a2", content: "Opening prayer" }] },
+    { id: "s2", name: "Deleted Section", actions: [{ id: "a3", content: "Craft time" }, { id: "a4", content: "Snack" }] },
+    { id: "s3", name: "Bible Story", actions: [{ id: "a5", content: "Read the story" }, { id: "a6", content: "Watch the video" }] }
+  ]
+});
+
+// Section s1 left untouched, s2 deleted, s3 expanded to actions with a6 deleted.
+const customizedPlanItems = (): PlanItemInterface[] => [
+  { id: "pi1", itemType: "providerSection", relatedId: "s1", label: "Welcome" },
+  {
+    id: "pi2",
+    itemType: "header",
+    label: "Lesson",
+    children: [{ id: "pi3", itemType: "providerPresentation", relatedId: "a5", label: "Read the story" }]
+  }
+];
+
+test.describe("Issue 979: lesson print formats honor plan customizations", () => {
+  test("drops sections the church deleted from the plan", () => {
+    const result = filterFeedByPlanItems(lessonFeed(), customizedPlanItems());
+    expect(result?.sections?.map((s) => s.id)).toEqual(["s1", "s3"]);
+  });
+
+  test("keeps an untouched section's actions intact", () => {
+    const result = filterFeedByPlanItems(lessonFeed(), customizedPlanItems());
+    const welcome = result?.sections?.find((s) => s.id === "s1");
+    expect(welcome?.actions?.map((a) => a.id)).toEqual(["a1", "a2"]);
+  });
+
+  test("keeps only the surviving actions of an expanded section", () => {
+    const result = filterFeedByPlanItems(lessonFeed(), customizedPlanItems());
+    const story = result?.sections?.find((s) => s.id === "s3");
+    expect(story?.actions?.map((a) => a.id)).toEqual(["a5"]);
+  });
+
+  test("matches id-less actions by content when a plan item carries the same label", () => {
+    const feed = lessonFeed();
+    feed.sections![2].actions = [{ content: "Read the story" }, { content: "Watch the video" }];
+    const result = filterFeedByPlanItems(feed, customizedPlanItems());
+    const story = result?.sections?.find((s) => s.id === "s3");
+    expect(story?.actions?.map((a) => a.content)).toEqual(["Read the story"]);
+  });
+
+  test("does not mutate the feed it was handed", () => {
+    const feed = lessonFeed();
+    filterFeedByPlanItems(feed, customizedPlanItems());
+    expect(feed.sections).toHaveLength(3);
+    expect(feed.sections?.[2].actions).toHaveLength(2);
+  });
+
+  test("leaves the feed alone when the plan has no items", () => {
+    const result = filterFeedByPlanItems(lessonFeed(), []);
+    expect(result?.sections?.map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `filterFeedByPlanItems` so Lessons.church / Color Coded / Script print formats drop sections and actions the church deleted from the plan.
- Add a unit-style Playwright spec covering deleted sections, expanded sections, and id-less action matching.

Fixes ChurchApps/ChurchAppsSupport#979

## Test plan
- [ ] `npx playwright test --config=playwright.unit.config.ts` is not required; run `npx playwright test tests/issue-979.spec.ts` with a config that skips globalSetup/webServer, or run the helper tests in isolation — 6 passed locally.
- [ ] Open a customized lesson plan print page and confirm deleted sections/actions do not appear on Lessons.church, Color Coded, or Script tabs.