### PR TITLE
Bust the edited site's cache from the website builder

### DIFF
--- a/src/site/admin/ContentEditor.tsx
+++ b/src/site/admin/ContentEditor.tsx
@@ -1,7 +1,7 @@
 ﻿import { useEffect, useState, useContext, useRef, useCallback, useMemo, useSyncExternalStore } from "react";
 import { useNavigate } from "react-router-dom";
 import { ThemeProvider, createTheme, CssBaseline, useMediaQuery, Container, Skeleton, Box, Button, Icon, Typography } from "@mui/material";
-import type { BlockInterface, ElementInterface, PageInterface, SectionInterface, GlobalStyleInterface } from "../../helpers/Interfaces";
+import type { BlockInterface, ElementInterface, PageInterface, SectionInterface, GlobalStyleInterface, SiteInterface } from "../../helpers/Interfaces";
 import { ApiHelper, ArrayHelper, UserHelper } from "../../helpers";
 import { Permissions } from "@churchapps/helpers";
 import { Section } from "./Section";
@@ -29,6 +29,7 @@ import { useThemeMode } from "../../ThemeContext";
 import { SectionTemplatePicker } from "./templates/SectionTemplatePicker";
 import { buildTemplateSection, remapSectionContent, type SectionTemplateDef } from "./templates/sectionTemplates";
 import { trackSave, resetSaveStatus, subscribeSaveStatus, getSaveStatus, getLastSavedAt } from "./saveStatusTracker";
+import { setActiveSiteSubDomain } from "../siteCache";
 import { EDITOR_HOVER_CSS, getSelectionSuppressCss } from "./editorCss";
 import { AddSectionDivider } from "./AddSectionDivider";
 import { SelectionBreadcrumb, type BreadcrumbCrumb } from "./SelectionBreadcrumb";
@@ -226,6 +227,22 @@ export function ContentEditor(props: Props) {
   };
 
   useEffect(loadDataInternal, [props.pageId, props.blockId]);
+
+  // Every persisting mutation clears the public cache via trackSave; point it at this page's site.
+  const containerSiteId = (container as PageInterface)?.siteId;
+  useEffect(() => {
+    if (!containerSiteId) {
+      setActiveSiteSubDomain(null);
+      return;
+    }
+    ApiHelper.get("/sites", "MembershipApi")
+      .then((sites: SiteInterface[]) => {
+        const match = (Array.isArray(sites) ? sites : []).find((s) => s.id === containerSiteId);
+        setActiveSiteSubDomain(match?.subDomain || null);
+      })
+      .catch(() => setActiveSiteSubDomain(null));
+    return () => setActiveSiteSubDomain(null);
+  }, [containerSiteId]);
 
   useEffect(() => {
     if (container && !initialSnapshotSavedRef.current) {

--- a/src/site/siteCache.ts
+++ b/src/site/siteCache.ts
@@ -1,8 +1,13 @@
 import { UserHelper } from "@churchapps/apphelper";
 import { EnvironmentHelper } from "../helpers/EnvironmentHelper";
 
+let activeSubDomain: string | null = null;
+
+// Editors working on a secondary site must bust that site's tag, not the church's default.
+export const setActiveSiteSubDomain = (subDomain: string | null) => { activeSubDomain = subDomain; };
+
 export const clearSiteCache = (subDomain?: string) => {
-  const sd = subDomain || UserHelper.currentUserChurch?.church?.subDomain;
+  const sd = subDomain || activeSubDomain || UserHelper.currentUserChurch?.church?.subDomain;
   if (!sd) return;
   const b1Url = EnvironmentHelper.B1Url.replace("{subdomain}", sd);
   fetch(b1Url + "/api/revalidate/" + sd, { method: "POST" }).catch(() => { /* best-effort */ });

--- a/tests/issue-948.spec.ts
+++ b/tests/issue-948.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// Issue #948: deleting a section/element in the website builder left the public
+// b1.church page stale because nothing invalidated B1App's cache for that site.
+const srcDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src");
+const read = (rel: string) => fs.readFileSync(path.join(srcDir, rel), "utf8");
+
+const editor = () => read("site/admin/ContentEditor.tsx");
+
+const handlerBody = (source: string, name: string) => {
+  const start = source.indexOf(`const ${name} = `);
+  expect(start, `${name} not found in ContentEditor.tsx`).toBeGreaterThan(-1);
+  const end = source.indexOf("\n  const ", start + 1);
+  return source.slice(start, end === -1 ? source.length : end);
+};
+
+const PERSISTING_HANDLERS = [
+  "confirmSectionDelete",
+  "confirmElementDelete",
+  "handleSectionMove",
+  "handleElementMove",
+  "handleSectionDuplicate",
+  "handleElementDuplicate",
+  "handleDrop",
+  "handleTemplateSelect",
+  "handleSwitchLayout",
+  "handlePublish",
+  "confirmDiscardChanges",
+  "confirmUnpublish"
+];
+
+test.describe("issue-948 website builder cache invalidation", () => {
+  test("every persisting ContentEditor mutation routes through trackSave", () => {
+    const source = editor();
+    for (const name of PERSISTING_HANDLERS) {
+      expect(handlerBody(source, name), `${name} must wrap its save in trackSave()`).toContain("trackSave(");
+    }
+  });
+
+  test("no ContentEditor content write escapes trackSave", () => {
+    const source = editor().replace(/\s+/g, " ");
+    const writes = [...source.matchAll(/ApiHelper\.(post|delete)\(\s*[`"](\/(sections|elements|pages)[^`"]*)/g)];
+    expect(writes.length).toBeGreaterThan(5);
+    for (const match of writes) {
+      const before = source.slice(Math.max(0, match.index! - 120), match.index!);
+      expect(before, `unwrapped write to ${match[2]}`).toContain("trackSave(");
+    }
+  });
+
+  test("a settled save clears the public site cache", () => {
+    const tracker = read("site/admin/saveStatusTracker.ts");
+    expect(tracker).toContain('import { clearSiteCache } from "../siteCache"');
+    const settled = tracker.slice(tracker.indexOf("if (inflight === 0)"), tracker.indexOf("return result;"));
+    expect(settled).toContain("clearSiteCache()");
+  });
+
+  test("clearSiteCache prefers the active site over the church subdomain", () => {
+    const cache = read("site/siteCache.ts");
+    expect(cache).toContain("export const setActiveSiteSubDomain");
+    expect(cache).toContain("subDomain || activeSubDomain || UserHelper.currentUserChurch?.church?.subDomain");
+    expect(cache).toContain('fetch(b1Url + "/api/revalidate/" + sd, { method: "POST" })');
+  });
+
+  test("ContentEditor registers the edited page's site subdomain", () => {
+    const source = editor();
+    expect(source).toContain("setActiveSiteSubDomain");
+    expect(source).toContain('ApiHelper.get("/sites", "MembershipApi")');
+  });
+});


### PR DESCRIPTION
## Summary
- `clearSiteCache()` now prefers the page's site subdomain (via `setActiveSiteSubDomain`) over the church default, so website-builder mutations purge the public B1App tag that actually serves the page.
- ContentEditor registers the loaded page's site for the editing session and clears it on unmount.
- Unit-style spec covers trackSave wiring, cache-bust on settled save, and site-subdomain preference.

Fixes ChurchApps/ChurchAppsSupport#948

## Test plan
- [x] `npx playwright test --config=pw-unit-948.config.ts` — 5 passed (unit-style, no MySQL/webServer)
- [ ] Edit a page on a secondary site in the website builder, delete a section, confirm the public `{site}.b1.church` page updates without waiting for the 300s TTL
- [ ] Pages that have already been Published still need an explicit Publish click for draft deletions to go live (out of scope for this PR)