### PR TITLE
Add Anniversaries report tile

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2632,6 +2632,8 @@
       "report": "Report"
     },
     "reportsPage": {
+      "anniversaries": "Anniversaries",
+      "anniversariesDesc": "View upcoming anniversaries",
       "attTrend": "Attendance Trend",
       "attTrendDesc": "View attendance trends over time",
       "bDays": "Birthdays",

--- a/src/reports/ReportsPage.tsx
+++ b/src/reports/ReportsPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Locale, PageHeader } from "@churchapps/apphelper";
 import { Box, Card, CardContent, Typography, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Container, Paper } from "@mui/material";
-import { CakeOutlined as BirthdayIcon, TrendingUp as TrendIcon, Groups as GroupsIcon, Today as DailyIcon, VolunteerActivism as DonationIcon, BarChart as BarChartIcon } from "@mui/icons-material";
+import { CakeOutlined as BirthdayIcon, FavoriteOutlined as AnniversaryIcon, TrendingUp as TrendIcon, Groups as GroupsIcon, Today as DailyIcon, VolunteerActivism as DonationIcon, BarChart as BarChartIcon } from "@mui/icons-material";
 import { Link } from "react-router-dom";
 
 export const ReportsPage = () => {
@@ -11,6 +11,12 @@ export const ReportsPage = () => {
       label: Locale.label("reports.reportsPage.bDays"),
       icon: <BirthdayIcon />,
       description: Locale.label("reports.reportsPage.bDaysDesc")
+    },
+    {
+      path: "/reports/anniversaries",
+      label: Locale.label("reports.reportsPage.anniversaries"),
+      icon: <AnniversaryIcon />,
+      description: Locale.label("reports.reportsPage.anniversariesDesc")
     },
     {
       path: "/reports/attendanceTrend",


### PR DESCRIPTION
## Summary
- Add an Anniversaries tile on the reports page pointing at `/reports/anniversaries`.
- Add `reports.reportsPage.anniversaries` / `anniversariesDesc` locale keys (English).

Fixes ChurchApps/ChurchAppsSupport#987

Companion: Api report definition PR.

## Test plan
- [x] `node node_modules/eslint/bin/eslint.js src/reports/ReportsPage.tsx` — clean
- [ ] Open Reports and confirm the Anniversaries tile appears next to Birthdays
- [ ] Open the tile and confirm month/group filters run against the new report