### PR TITLE
Show a music-note icon for audio plan items

### DIFF
--- a/src/serving/components/planItem/PlanItemRow.tsx
+++ b/src/serving/components/planItem/PlanItemRow.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon } from "@mui/icons-material";
+import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon } from "@mui/icons-material";
 import { Locale } from "@churchapps/apphelper";
 import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
 import { type PlanItemInterface } from "../../../helpers";
 import { formatTime, formatClockTime } from "../PlanUtils";
 import { PlanItemIcon } from "./PlanItemIcon";
-import { type ProviderMediaInfo, matchProviderMedia, isVideoMedia, estimateSeconds } from "../planItemUtils";
+import { type ProviderMediaInfo, matchProviderMedia, isVideoMedia, isAudioMedia, estimateSeconds } from "../planItemUtils";
 
 interface Props {
   planItem: PlanItemInterface;
@@ -37,6 +37,7 @@ export const PlanItemRow: React.FC<Props> = ({
   const railLabel = excluded ? "—" : (serviceStartTime ? formatClockTime(serviceStartTime, startTime) : formatTime(startTime));
   const providerMedia = planItem.thumbnailUrl ? undefined : matchProviderMedia(planItem, mediaLookup);
   const showVideoThumb = !!providerMedia && isVideoMedia(planItem.label, providerMedia);
+  const showAudioIcon = !!providerMedia && isAudioMedia(planItem.label, providerMedia);
   // Untimed images show a planning estimate (~5:00) rather than an alarming 0:00 —
   // stored seconds stay 0 so playback leaves the volunteer in control.
   const storedSeconds = planItem.seconds ?? 0;
@@ -91,6 +92,13 @@ export const PlanItemRow: React.FC<Props> = ({
               }}
               sx={{ width: 80, height: 45, objectFit: "cover", borderRadius: 2, pointerEvents: "none", backgroundColor: "grey.900" }}
             />
+          ) : showAudioIcon ? (
+            <Box
+              component="span"
+              sx={{ display: "flex", alignItems: "center", justifyContent: "center", width: 80, height: 45, backgroundColor: "grey.300", borderRadius: 2 }}
+            >
+              <MusicNoteIcon sx={{ fontSize: 32, color: "text.secondary" }} />
+            </Box>
           ) : (
             <Box
               component="img"

--- a/src/serving/components/planItemUtils.ts
+++ b/src/serving/components/planItemUtils.ts
@@ -60,7 +60,7 @@ export async function duplicatePlanItem(planItem: PlanItemInterface): Promise<vo
 /** Fresh media info for a provider item, fetched per page load (provider links can expire). */
 export interface ProviderMediaInfo {
   url: string;
-  mediaType?: "video" | "image";
+  mediaType?: "video" | "image" | "audio";
   seconds?: number;
 }
 
@@ -86,6 +86,7 @@ export function matchProviderMedia(planItem: PlanItemInterface, lookup?: Record<
 }
 
 const VIDEO_EXT_PATTERN = /\.(mp4|webm|mov|m4v|avi|mkv)\s*(\?|#|$)/i;
+const AUDIO_EXT_PATTERN = /\.(mp3|m4a|aac|wav|flac|oga)\s*(\?|#|$)/i;
 
 /** Planning estimate for images. Stored seconds stay 0 so playback (FreePlay) leaves the
  * volunteer in control; this value is display/schedule-math only. */
@@ -96,13 +97,17 @@ export function estimateSeconds(planItem: PlanItemInterface, lookup?: Record<str
   if (planItem.seconds && planItem.seconds > 0) return planItem.seconds;
   if (planItem.itemType === "header") return 0;
   const media = matchProviderMedia(planItem, lookup);
-  if (media && !isVideoMedia(planItem.label, media)) return ESTIMATED_IMAGE_SECONDS;
+  if (media && !isVideoMedia(planItem.label, media) && !isAudioMedia(planItem.label, media)) return ESTIMATED_IMAGE_SECONDS;
   return 0;
 }
 
 /** Older provider versions omit mediaType, so also sniff the file extension from the label/url. */
 export function isVideoMedia(label: string | undefined, media: ProviderMediaInfo): boolean {
   return media.mediaType === "video" || VIDEO_EXT_PATTERN.test(label || "") || VIDEO_EXT_PATTERN.test(media.url.split("?")[0]);
+}
+
+export function isAudioMedia(label: string | undefined, media: ProviderMediaInfo): boolean {
+  return media.mediaType === "audio" || AUDIO_EXT_PATTERN.test(label || "") || AUDIO_EXT_PATTERN.test(media.url.split("?")[0]);
 }
 
 /** Reads a video's duration (seconds) by loading just its metadata. Resolves null on error/timeout. */


### PR DESCRIPTION
## Summary
- Sniff audio URLs (`.mp3` `.m4a` `.aac` `.wav` `.flac` `.oga`) on plan rows.
- Render a music-note icon instead of a broken `<img>` thumbnail.
- Do not apply the image planning estimate to audio items.

Related to ChurchApps/ChurchAppsSupport#960

Core inline player already shipped on main (`2ddb76d1`).

## Test plan
- [x] `./node_modules/.bin/eslint` on `planItemUtils.ts` and `PlanItemRow.tsx` — clean
- [ ] Preview a service order with an MP3-linked item and confirm the music-note icon
- [ ] Confirm video thumbs and image thumbs are unchanged