### PR TITLE
Allow renaming workflow categories

### DIFF
--- a/src/serving/tasks/workflows/components/WorkflowEdit.tsx
+++ b/src/serving/tasks/workflows/components/WorkflowEdit.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, Typography, Stack, Box, Button, TextField, Switch, FormControlLabel, FormControl, InputLabel, Select, MenuItem, type SelectChangeEvent } from "@mui/material";
 import React from "react";
 import { ApiHelper, Locale } from "@churchapps/apphelper";
-import { ViewKanban as WorkflowsIcon, Save as SaveIcon, Cancel as CancelIcon, Delete as DeleteIcon, Check as CheckIcon } from "@mui/icons-material";
+import { ViewKanban as WorkflowsIcon, Save as SaveIcon, Cancel as CancelIcon, Delete as DeleteIcon, Check as CheckIcon, Edit as EditIcon } from "@mui/icons-material";
 import { AppIconButton } from "../../../../components/ui/AppIconButton";
 import { useConfirmDelete } from "../../../../hooks";
 import { type WorkflowInterface, type WorkflowCategoryInterface } from "@churchapps/helpers";
@@ -21,6 +21,7 @@ export const WorkflowEdit = (props: Props) => {
   const [workflow, setWorkflow] = React.useState<WorkflowInterface | null>(null);
   const [categories, setCategories] = React.useState<WorkflowCategoryInterface[]>([]);
   const [addingCategory, setAddingCategory] = React.useState(false);
+  const [editingCategory, setEditingCategory] = React.useState<WorkflowCategoryInterface | null>(null);
   const [newCategoryName, setNewCategoryName] = React.useState("");
   const { confirm, ConfirmDialogElement } = useConfirmDelete();
   // Hoisted: the compiler emits a non-optional guard read (workflow.id) for the
@@ -69,8 +70,20 @@ export const WorkflowEdit = (props: Props) => {
     props.onCategoriesChanged?.();
   };
 
+  const handleRenameCategory = async () => {
+    const name = newCategoryName.trim();
+    if (!name || !editingCategory) return;
+    const result = await ApiHelper.post("/workflowCategories", [{ id: editingCategory.id, name }], "DoingApi");
+    const updated: WorkflowCategoryInterface = result[0];
+    setCategories(categories.map((c) => (c.id === updated.id ? updated : c)));
+    setEditingCategory(null);
+    setNewCategoryName("");
+    props.onCategoriesChanged?.();
+  };
+
   const cancelAddCategory = () => {
     setAddingCategory(false);
+    setEditingCategory(null);
     setNewCategoryName("");
   };
 
@@ -100,19 +113,19 @@ export const WorkflowEdit = (props: Props) => {
               variant="outlined"
             />
 
-            {addingCategory ? (
+            {addingCategory || editingCategory ? (
               <Stack direction="row" spacing={1} alignItems="center">
                 <TextField
                   fullWidth
                   autoFocus
-                  label={Locale.label("tasks.workflowCategories.newCategory")}
+                  label={editingCategory ? Locale.label("tasks.workflowCategories.title") : Locale.label("tasks.workflowCategories.newCategory")}
                   value={newCategoryName}
                   onChange={(e) => setNewCategoryName(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAddCategory(); } }}
+                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (editingCategory) handleRenameCategory(); else handleAddCategory(); } }}
                   data-testid="new-category-input"
                   variant="outlined"
                 />
-                <AppIconButton label={Locale.label("common.save")} icon={<CheckIcon />} onClick={handleAddCategory} data-testid="new-category-save" />
+                <AppIconButton label={Locale.label("common.save")} icon={<CheckIcon />} onClick={editingCategory ? handleRenameCategory : handleAddCategory} data-testid="new-category-save" />
                 <AppIconButton label={Locale.label("common.cancel")} icon={<CancelIcon />} onClick={cancelAddCategory} data-testid="new-category-cancel" />
               </Stack>
             ) : (
@@ -121,7 +134,15 @@ export const WorkflowEdit = (props: Props) => {
                 <Select displayEmpty label={Locale.label("tasks.workflowCategories.title")} value={workflow?.categoryId || ""} name="categoryId" onChange={handleChange} data-testid="workflow-category-select">
                   <MenuItem value="">{Locale.label("tasks.workflowCategories.uncategorized")}</MenuItem>
                   {categories.map((c) => (
-                    <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>
+                    <MenuItem key={c.id} value={c.id} sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 1 }}>
+                      {c.name}
+                      <AppIconButton
+                        label={Locale.label("common.edit")}
+                        icon={<EditIcon />}
+                        onClick={(e) => { e.stopPropagation(); setEditingCategory(c); setNewCategoryName(c.name || ""); }}
+                        data-testid={`workflow-category-edit-${c.id}`}
+                      />
+                    </MenuItem>
                   ))}
                   <MenuItem value={ADD_CATEGORY} data-testid="workflow-category-add">+ {Locale.label("tasks.workflowCategories.addCategory")}</MenuItem>
                 </Select>


### PR DESCRIPTION
## Summary
- Add an edit icon on each workflow category so names can be updated after creation (discussion #981).
- Reuses the existing add-category field and `POST /workflowCategories` upsert (pass `id` to rename).

## Test plan
- [ ] Open Serving → Tasks → Workflows, edit a workflow
- [ ] Click the pencil on an existing category, rename it, save — list and API should show the new name
- [ ] Cancel leaves the category unchanged; Add Category still works