### PR TITLE
Add live ChordPro preview on arrangement edit

### DIFF
--- a/src/helpers/ChordProHelper.test.ts
+++ b/src/helpers/ChordProHelper.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ChordProHelper } from "./ChordProHelper.ts";
+
+describe("ChordProHelper.transposeChords", () => {
+  it("transposes basic chords", () => {
+    assert.equal(ChordProHelper.transposeChords("[C] hello", 2), "[D] hello");
+    assert.equal(ChordProHelper.transposeChords("[Am] world", 2), "[Bm] world");
+  });
+
+  it("transposes extended chords", () => {
+    assert.equal(ChordProHelper.transposeChords("[A7] chord", 2), "[B7] chord");
+    assert.equal(ChordProHelper.transposeChords("[Gmaj7] chord", 2), "[Amaj7] chord");
+    assert.equal(ChordProHelper.transposeChords("[Csus4] chord", 2), "[Dsus4] chord");
+    assert.equal(ChordProHelper.transposeChords("[Dadd9] chord", 2), "[Eadd9] chord");
+    assert.equal(ChordProHelper.transposeChords("[Cm7] chord", 2), "[Dm7] chord");
+  });
+
+  it("transposes slash chords, preserving the bass note interval", () => {
+    assert.equal(ChordProHelper.transposeChords("[C/E] chord", 2), "[D/F#] chord");
+    assert.equal(ChordProHelper.transposeChords("[G/B] chord", -2), "[F/A] chord");
+  });
+
+  it("transposes sharps and flats", () => {
+    assert.equal(ChordProHelper.transposeChords("[F#] chord", 1), "[G] chord");
+    assert.equal(ChordProHelper.transposeChords("[Bb] chord", 1), "[B] chord");
+  });
+
+  it("leaves section header lines untouched", () => {
+    assert.equal(ChordProHelper.transposeChords("[Verse 1]", 2), "[Verse 1]");
+  });
+
+  it("wraps around the octave in both directions", () => {
+    assert.equal(ChordProHelper.transposeChords("[B]", 1), "[C]");
+    assert.equal(ChordProHelper.transposeChords("[C]", -1), "[B]");
+  });
+});
+
+describe("ChordProHelper.formatLyrics", () => {
+  it("renders section header lines as headers", () => {
+    const html = ChordProHelper.formatLyrics("[Verse 1]", 0);
+    assert.equal(html, '<h3 style="margin-bottom:0px">Verse 1</h3>');
+  });
+
+  it("renders lyric lines with chords as superscript", () => {
+    const html = ChordProHelper.formatLyrics("[G]Amazing [C]grace", 0);
+    assert.equal(html, '<div class="line"><sup>G</sup>Amazing <sup>C</sup>grace</div>');
+  });
+
+  it("renders blank lines as line breaks", () => {
+    assert.equal(ChordProHelper.formatLyrics("", 0), "<br/>");
+  });
+
+  it("transposes chords by the given key offset", () => {
+    const html = ChordProHelper.formatLyrics("[C]hello", 2);
+    assert.equal(html, '<div class="line"><sup>D</sup>hello</div>');
+  });
+
+  it("escapes html in lyric lines", () => {
+    const html = ChordProHelper.formatLyrics("<script>", 0);
+    assert.equal(html, '<div class="line">&lt;script&gt;</div>');
+  });
+});

--- a/src/helpers/ChordProHelper.ts
+++ b/src/helpers/ChordProHelper.ts
@@ -35,7 +35,7 @@ export class ChordProHelper {
   };
 
   static transposeChords = (line: string, halfSteps: number) => {
-    const chords = line.match(/\[[A-G][#bm]?(\/[A-G][#bm]?)?\]/g);
+    const chords = line.match(/\[[A-G][#b]?[^/\]]*(\/[A-G][#b]?)?\]/g);
     if (chords) {
       chords.forEach((chord) => {
         const newChord = this.transposeChord(chord.substring(1, chord.length - 1), halfSteps);
@@ -85,12 +85,6 @@ export class ChordProHelper {
     const newRoot = this.noteNames[newIndex];
 
     return newRoot + modifier;
-  };
-
-  static transposeLyrics = () => {
-    const result: string[] = [];
-
-    return result.join("\n");
   };
 
   static escapeHtml = (s: string) => s

--- a/src/serving/songs/components/ArrangementEdit.tsx
+++ b/src/serving/songs/components/ArrangementEdit.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { ApiHelper, Locale } from "@churchapps/apphelper";
 import { type ArrangementInterface } from "../../../helpers";
-import { TextField } from "@mui/material";
+import { ChordProHelper } from "../../../helpers/ChordProHelper";
+import { Box, Grid, TextField, Typography } from "@mui/material";
 import { FormCard } from "../../../components/ui";
 import { useConfirmDelete } from "../../../hooks";
 
@@ -16,8 +17,9 @@ type AnyRecord = Record<string, any>;
 
 export const ArrangementEdit = (props: Props) => {
   "use no memo"; // compiler caches register() results, breaking RHF field re-registration after reset()
-  const { register, handleSubmit, reset } = useForm<AnyRecord>({ defaultValues: { name: "", lyrics: "" } });
+  const { register, handleSubmit, reset, watch } = useForm<AnyRecord>({ defaultValues: { name: "", lyrics: "" } });
   const { confirm, ConfirmDialogElement } = useConfirmDelete();
+  const lyrics = watch("lyrics");
 
   useEffect(() => {
     if (props.arrangement) reset({ ...props.arrangement });
@@ -49,7 +51,34 @@ export const ArrangementEdit = (props: Props) => {
         <TextField label={Locale.label("songs.details.meter") || "Meter"} fullWidth {...register("meter")} />
         <TextField label={Locale.label("songs.details.length") || "Length"} type="number" placeholder="seconds" fullWidth {...register("seconds", { valueAsNumber: true })} />
         <TextField label="Sequence" fullWidth placeholder="Verse 1, Chorus, Verse 2, Chorus, Bridge" {...register("sequence")} />
-        <TextField label={Locale.label("songs.arrangement.lyrics")} multiline fullWidth placeholder={Locale.label("placeholders.song.lyrics")} {...register("lyrics")} maxRows={25} sx={{ "& textarea": { maxHeight: 600, overflowY: "auto !important" } }} />
+        <Typography variant="caption" color="text.secondary">
+          {Locale.label("songs.arrangement.chordProHint") || "ChordPro format: [G] inline chords, [Verse 1] section headers."}
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TextField label={Locale.label("songs.arrangement.lyrics")} multiline fullWidth placeholder={Locale.label("placeholders.song.lyrics")} {...register("lyrics")} maxRows={25} sx={{ "& textarea": { maxHeight: 600, overflowY: "auto !important" } }} />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Box
+              className="chordPro"
+              sx={{
+                backgroundColor: "background.subtle",
+                color: "text.primary",
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1,
+                p: 2,
+                minHeight: 200,
+                maxHeight: 600,
+                overflowY: "auto",
+                fontFamily: "monospace",
+                fontSize: "0.875rem",
+                lineHeight: 1.6
+              }}
+              dangerouslySetInnerHTML={{ __html: ChordProHelper.formatLyrics(lyrics || "", 0) }}
+            />
+          </Grid>
+        </Grid>
       </FormCard>
     </>
   );


### PR DESCRIPTION
## Summary
- Live side-by-side ChordPro preview while editing arrangement lyrics (ChurchAppsSupport #995)
- Transpose extended chords (A7, Gmaj7, Csus4, etc.) instead of leaving them in the original key
- Unit tests for ChordProHelper parse/transpose/format

## Test plan
- [ ] `npx node@22 --experimental-strip-types --test src/helpers/ChordProHelper.test.ts` (11 passing)
- [ ] Open Songs → arrangement edit, type `[G]Amazing [C]grace` and `[Verse 1]` and confirm preview superscripts chords and headers
- [ ] Confirm extended chords like `[Gmaj7]` transpose on the song view