### PR TITLE
Scroll the logo image editor into view when it opens

### DIFF
--- a/src/site/components/AppearanceEdit.tsx
+++ b/src/site/components/AppearanceEdit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Resizer from "react-image-file-resizer";
 import { Box, Typography, Stack, Button, Card, CardContent, alpha, TextField } from "@mui/material";
 import { Image as ImageIcon, CloudUpload as CloudUploadIcon, Edit as EditIcon } from "@mui/icons-material";
@@ -66,6 +66,7 @@ export function AppearanceEdit(props: Props) {
   const [currentEditLogo, setCurrentEditLogo] = useState<string>("");
   const [currentUrl, setCurrentUrl] = useState<string | null>("about:blank");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const editorRef = useRef<HTMLDivElement>(null);
 
   const init = () => {
     const startingUrl = (ArrayHelper.getOne(props.settings || [], "keyName", currentEditLogo))?.value;
@@ -73,6 +74,11 @@ export function AppearanceEdit(props: Props) {
   };
 
   useEffect(init, [currentEditLogo]);
+
+  // The editor renders above the logo cards, so reveal it after the click that opened it.
+  useEffect(() => {
+    if (editLogo) editorRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }, [editLogo]);
 
   const getValue = async (keyName: string, dataURL: string) => {
     let url = dataURL;
@@ -204,7 +210,7 @@ export function AppearanceEdit(props: Props) {
 
   return (
     <Box sx={{ maxWidth: 1200 }}>
-      {getLogoEditor(currentEditLogo)}
+      <Box ref={editorRef}>{getLogoEditor(currentEditLogo)}</Box>
 
       <Box sx={{ backgroundColor: "primary.light", color: "#FFF", p: 3, borderRadius: "12px 12px 0 0", mb: 0 }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">

--- a/tests/issue-997.spec.ts
+++ b/tests/issue-997.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+import { login } from "./helpers/auth";
+import { navigateTo } from "./helpers/navigation";
+
+// Issue #997: the ImageEditor renders above the Logo & Branding card. Clicking an
+// "Edit ... Logo" button after scrolling down left the editor off-screen, so nothing
+// appeared to happen until the user scrolled back up.
+const LOGO_BUTTONS = ["logoLight", "logoDark", "ogImage", "favicon_400x400"];
+
+const openLogoSection = async (page: import("@playwright/test").Page) => {
+  await navigateTo(page, "appearance");
+  await page.locator('[data-testid="style-option-logo"]').click();
+  await expect(page.locator('[data-testid="save-appearance-button"]')).toBeVisible({ timeout: 10000 });
+};
+
+test.describe("issue-997 logo editor scrolls into view", () => {
+  for (const name of LOGO_BUTTONS) {
+    test(`${name} editor is visible immediately after clicking its Edit button`, async ({ page }) => {
+      await login(page);
+      await openLogoSection(page);
+
+      const button = page.locator(`[data-testid="${name}-button"]`);
+      await button.scrollIntoViewIfNeeded();
+      // Pin the button to the top of the viewport so the editor's insertion point is above it.
+      await button.evaluate((el) => el.scrollIntoView({ block: "start" }));
+      await button.click();
+
+      const editor = page.locator("#cropperBox");
+      await expect(editor).toBeVisible({ timeout: 10000 });
+
+      const viewportHeight = page.viewportSize()!.height;
+      await expect.poll(async () => (await editor.boundingBox())?.y ?? -9999, { timeout: 10000 })
+        .toBeGreaterThanOrEqual(0);
+      const box = (await editor.boundingBox())!;
+      expect(box.y, "editor top must be inside the viewport").toBeLessThan(viewportHeight);
+    });
+  }
+});


### PR DESCRIPTION
Clicking Edit on a logo in Appearance opened the image editor above the card, out of view, so it looked like nothing happened. It scrolls into view now.

Fixes ChurchApps/ChurchAppsSupport#997