### PR TITLE
Add a Collapse to Section control for expanded plan actions

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2173,6 +2173,8 @@
     },
     "planItem": {
       "addItem": "Add Item",
+      "collapseToSection": "Collapse to Section",
+      "collapseToSectionConfirm": "Collapse these actions back into a single section? Any changes made to the individual actions will be lost.",
       "duration": "Duration",
       "editItem": "Edit Item",
       "editSection": "Edit Section",

--- a/src/serving/components/PlanItem.tsx
+++ b/src/serving/components/PlanItem.tsx
@@ -8,11 +8,12 @@ import { type TimeInterface, type PlanItemTimeInterface } from "@churchapps/help
 import { ApiHelper, Locale } from "@churchapps/apphelper";
 import { SongDialog } from "./SongDialog";
 import { LessonDialog } from "./LessonDialog";
-import { getNextChildSort, estimateSeconds, duplicatePlanItem, type ProviderMediaInfo } from "./planItemUtils";
+import { getNextChildSort, estimateSeconds, duplicatePlanItem, findExpandedRuns, type ProviderMediaInfo } from "./planItemUtils";
 import { ActionDialog } from "./ActionDialog";
 import { ActionSelector } from "./ActionSelector";
 import { PlanItemHeader, PlanItemRow } from "./planItem/index";
 import { usePlanItemExpand } from "./planItem/usePlanItemExpand";
+import { useConfirmDelete } from "../../hooks";
 
 interface Props {
   planItem: PlanItemInterface;
@@ -30,6 +31,8 @@ interface Props {
   selectedServiceTimeId?: string;
   excluded?: boolean;
   mediaLookup?: Record<string, ProviderMediaInfo>;
+  /** Set on the first item of a run of actions expanded from one section, enabling the collapse control. */
+  collapseItems?: PlanItemInterface[];
 }
 
 export const PlanItem = React.memo((props: Props) => {
@@ -41,13 +44,25 @@ export const PlanItem = React.memo((props: Props) => {
   const open = Boolean(anchorEl);
 
   // Use the expand hook for section expansion functionality
-  const { handleExpandToActions } = usePlanItemExpand({
+  const { handleExpandToActions, canCollapse, handleCollapseToSection } = usePlanItemExpand({
     planItem: props.planItem,
     associatedProviderId: props.associatedProviderId,
     associatedContentPath: props.associatedContentPath,
     ministryId: props.ministryId,
+    collapseItems: props.collapseItems,
     onChange: props.onChange
   });
+  const { confirm, ConfirmDialogElement } = useConfirmDelete();
+
+  const showCollapse = canCollapse && !props.readOnly;
+  const handleCollapseClick = async () => {
+    const confirmed = await confirm(Locale.label("plans.planItem.collapseToSectionConfirm"), {
+      title: Locale.label("plans.planItem.collapseToSection"),
+      confirmLabel: Locale.label("plans.planItem.collapseToSection"),
+      "data-testid": "confirm-collapse-dialog"
+    });
+    if (confirmed) await handleCollapseToSection();
+  };
 
   const handleClose = () => {
     setAnchorEl(null);
@@ -130,6 +145,11 @@ export const PlanItem = React.memo((props: Props) => {
     return (props.exclusions || []).some((ex) => ex.planItemId === childId && ex.timeId === props.selectedServiceTimeId && ex.excluded);
   };
 
+  const expandedRuns = React.useMemo(
+    () => (props.readOnly ? new Map<string, PlanItemInterface[]>() : findExpandedRuns(props.planItem.children || [])),
+    [props.planItem.children, props.readOnly]
+  );
+
   const getChildren = () => {
     const result: JSX.Element[] = [];
     let cumulativeTime = props.startTime || 0;
@@ -137,7 +157,7 @@ export const PlanItem = React.memo((props: Props) => {
       const childStartTime = cumulativeTime;
       const childExcluded = c.itemType !== "header" && isChildExcluded(c.id || "");
       const childPlanItem = (
-        <PlanItem key={c.id} planItem={c} setEditPlanItem={props.setEditPlanItem} readOnly={props.readOnly} showItemDrop={props.showItemDrop} onDragChange={props.onDragChange} onChange={props.onChange} startTime={childStartTime} associatedContentPath={props.associatedContentPath} associatedProviderId={props.associatedProviderId} ministryId={props.ministryId} serviceTime={props.serviceTime} exclusions={props.exclusions} selectedServiceTimeId={props.selectedServiceTimeId} excluded={childExcluded} mediaLookup={props.mediaLookup} />
+        <PlanItem key={c.id} planItem={c} setEditPlanItem={props.setEditPlanItem} readOnly={props.readOnly} showItemDrop={props.showItemDrop} onDragChange={props.onDragChange} onChange={props.onChange} startTime={childStartTime} associatedContentPath={props.associatedContentPath} associatedProviderId={props.associatedProviderId} ministryId={props.ministryId} serviceTime={props.serviceTime} exclusions={props.exclusions} selectedServiceTimeId={props.selectedServiceTimeId} excluded={childExcluded} mediaLookup={props.mediaLookup} collapseItems={expandedRuns.get(c.id || "")} />
       );
       result.push(
         <React.Fragment key={c.id || `child-${index}`}>
@@ -200,6 +220,7 @@ export const PlanItem = React.memo((props: Props) => {
       onLabelClick={onLabelClick}
       onEditClick={() => props.setEditPlanItem?.(props.planItem)}
       onDuplicateClick={handleDuplicate}
+      onCollapseClick={showCollapse ? handleCollapseClick : undefined}
       mediaLookup={props.mediaLookup}
     />
   );
@@ -234,6 +255,7 @@ export const PlanItem = React.memo((props: Props) => {
   return (
     <>
       {getPlanItem()}
+      {showCollapse && ConfirmDialogElement}
       {props.planItem?.itemType === "header" && !props.readOnly && (
         <Menu id="header-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
           <MenuItem onClick={addSong}>

--- a/src/serving/components/planItem/PlanItemRow.tsx
+++ b/src/serving/components/planItem/PlanItemRow.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon } from "@mui/icons-material";
+import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon, UnfoldLess as UnfoldLessIcon } from "@mui/icons-material";
 import { Locale } from "@churchapps/apphelper";
 import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
 import { type PlanItemInterface } from "../../../helpers";
@@ -17,6 +17,7 @@ interface Props {
   onLabelClick?: () => void;
   onEditClick: () => void;
   onDuplicateClick?: () => void;
+  onCollapseClick?: () => void;
   mediaLookup?: Record<string, ProviderMediaInfo>;
 }
 
@@ -32,6 +33,7 @@ export const PlanItemRow: React.FC<Props> = ({
   onLabelClick,
   onEditClick,
   onDuplicateClick,
+  onCollapseClick,
   mediaLookup
 }) => {
   const railLabel = excluded ? "—" : (serviceStartTime ? formatClockTime(serviceStartTime, startTime) : formatTime(startTime));
@@ -149,6 +151,20 @@ export const PlanItemRow: React.FC<Props> = ({
       <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0, ml: 1.5 }}>
         {!readOnly && (
           <>
+            {onCollapseClick && (
+              <Box
+                component="button"
+                type="button"
+                className="actionButton rowControl"
+                data-testid="collapse-to-section-button"
+                onClick={(e: React.MouseEvent) => { e.stopPropagation(); onCollapseClick(); }}
+                aria-label={Locale.label("plans.planItem.collapseToSection")}
+                title={Locale.label("plans.planItem.collapseToSection")}
+                sx={{ border: 0, cursor: "pointer", color: "primary.main", background: "transparent" }}
+              >
+                <UnfoldLessIcon />
+              </Box>
+            )}
             <Box
               component="button"
               type="button"

--- a/src/serving/components/planItem/usePlanItemExpand.ts
+++ b/src/serving/components/planItem/usePlanItemExpand.ts
@@ -2,13 +2,15 @@ import { useState, useCallback } from "react";
 import { ApiHelper } from "@churchapps/apphelper";
 import { navigateToPath, type Instructions, type InstructionItem } from "@churchapps/content-providers";
 import { type PlanItemInterface } from "../../../helpers";
-import { findThumbnailRecursive, findByRelatedId } from "../planItemUtils";
+import { findThumbnailRecursive, findByRelatedId, getExpandedSectionPath } from "../planItemUtils";
 
 interface ExpandOptions {
   planItem: PlanItemInterface;
   associatedProviderId?: string;
   associatedContentPath?: string;
   ministryId?: string;
+  /** Contiguous run of action items this section was expanded into, when this item starts one. */
+  collapseItems?: PlanItemInterface[];
   onChange?: () => void;
   onError?: (message: string) => void;
 }
@@ -17,16 +19,19 @@ interface ExpandResult {
   isExpanding: boolean;
   canExpand: boolean;
   handleExpandToActions: () => Promise<void>;
+  canCollapse: boolean;
+  handleCollapseToSection: () => Promise<void>;
 }
 
 /** Expand a section plan item into its child action items via provider or plan-level association. */
 export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
-  const { planItem, associatedProviderId, associatedContentPath, ministryId, onChange, onError } = options;
+  const { planItem, associatedProviderId, associatedContentPath, ministryId, collapseItems, onChange, onError } = options;
   const [isExpanding, setIsExpanding] = useState(false);
 
   const canExpandViaProvider = !!(planItem.providerId && planItem.providerPath && planItem.providerContentPath);
   const canExpandViaPlan = !!(associatedProviderId && associatedContentPath && planItem.relatedId);
   const canExpand = canExpandViaProvider || canExpandViaPlan;
+  const canCollapse = !!(ministryId && collapseItems && collapseItems.length > 1 && getExpandedSectionPath(collapseItems[0]));
 
   const createActionItems = useCallback((
     section: InstructionItem,
@@ -138,9 +143,56 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
     }
   }, [canExpand, canExpandViaProvider, expandViaProvider, expandViaPlan, onChange, onError]);
 
+
+  /** Inverse of handleExpandToActions: re-resolves the section from the provider and swaps the run back. */
+  const handleCollapseToSection = useCallback(async () => {
+    const first = collapseItems?.[0];
+    const sectionPath = first ? getExpandedSectionPath(first) : null;
+    if (!first || !sectionPath || !ministryId) return;
+
+    try {
+      const instructions: Instructions = await ApiHelper.post(
+        "/providerProxy/getInstructions",
+        { ministryId, providerId: first.providerId, path: first.providerPath },
+        "DoingApi"
+      );
+      const section = instructions?.items ? navigateToPath(instructions, sectionPath) : null;
+      if (!section) throw new Error("Section no longer exists in the provider content");
+
+      // Post the replacement first so a failure leaves the actions intact.
+      const saved = await ApiHelper.post("/planItems", [
+        {
+          planId: first.planId,
+          parentId: first.parentId,
+          sort: (first.sort || 1) - 0.5,
+          itemType: "providerSection",
+          relatedId: section.relatedId || section.id || "",
+          label: section.label || "",
+          description: section.content,
+          seconds: section.seconds || 0,
+          providerId: first.providerId,
+          providerPath: first.providerPath,
+          providerContentPath: sectionPath,
+          thumbnailUrl: findThumbnailRecursive(section)
+        }
+      ], "DoingApi");
+
+      for (const item of collapseItems || []) {
+        if (item.id) await ApiHelper.delete(`/planItems/${item.id}`, "DoingApi");
+      }
+      if (saved?.[0]) await ApiHelper.post("/planItems/sort", saved[0], "DoingApi");
+      if (onChange) onChange();
+    } catch (error) {
+      console.error("Error collapsing section:", error);
+      if (onError) onError("Failed to collapse section");
+    }
+  }, [collapseItems, ministryId, onChange, onError]);
+
   return {
     isExpanding,
     canExpand,
-    handleExpandToActions
+    handleExpandToActions,
+    canCollapse,
+    handleCollapseToSection
   };
 }

--- a/src/serving/components/planItemUtils.ts
+++ b/src/serving/components/planItemUtils.ts
@@ -42,6 +42,35 @@ export function findByRelatedId(items: InstructionItem[], relatedId: string, par
   return null;
 }
 
+/** "Expand to Actions" stamps each generated action with `${sectionPath}.${index}`, so the
+ * section's own content path is the action's path minus that trailing index. */
+export function getExpandedSectionPath(item: PlanItemInterface): string | null {
+  if (!isPresentationType(item.itemType) || !item.providerId || !item.providerPath) return null;
+  return /^(.+)\.\d+$/.exec(item.providerContentPath || "")?.[1] || null;
+}
+
+/** Contiguous runs of action items expanded from the same section, keyed by the run's first item id. */
+export function findExpandedRuns(items: PlanItemInterface[]): Map<string, PlanItemInterface[]> {
+  const runs = new Map<string, PlanItemInterface[]>();
+  let run: PlanItemInterface[] = [];
+  let key: string | null = null;
+  const flush = () => {
+    if (run.length > 1 && run[0].id) runs.set(run[0].id, run);
+    run = [];
+  };
+  items.forEach((item) => {
+    const sectionPath = getExpandedSectionPath(item);
+    const itemKey = sectionPath ? `${item.providerId}|${item.providerPath}|${sectionPath}` : null;
+    if (itemKey !== key) {
+      flush();
+      key = itemKey;
+    }
+    if (itemKey) run.push(item);
+  });
+  flush();
+  return runs;
+}
+
 /** Handles undefined/null children arrays to avoid NaN. */
 export function getNextChildSort(children: PlanItemInterface[] | undefined | null): number {
   return (children?.length ?? 0) + 1;

--- a/tests/issue-996-collapse.spec.ts
+++ b/tests/issue-996-collapse.spec.ts
@@ -1,0 +1,133 @@
+import { request as pwRequest, type APIRequestContext } from "@playwright/test";
+import { loggedInTest as test, expect } from "./helpers/test-fixtures";
+
+// Issue #996 (fix 2): "Expand to Actions" permanently rewrote the plan with no way back.
+// The plan is seeded through DoingApi and the provider is mocked at the API proxy, since
+// no content provider is linked in the local stack.
+const API = "http://localhost:8084";
+
+const INSTRUCTIONS = {
+  name: "Collapse Repro Lesson",
+  items: [
+    {
+      id: "COLHEAD1",
+      itemType: "header",
+      relatedId: "COLHEAD1",
+      label: "Collapse Repro Header",
+      children: [
+        {
+          id: "COLSEC1",
+          itemType: "section",
+          relatedId: "COLSEC1",
+          label: "Collapse Repro Section",
+          content: "Section notes",
+          seconds: 300,
+          children: [
+            { id: "COLACT1", itemType: "action", relatedId: "COLACT1", label: "Collapse Repro Action One", seconds: 120 },
+            { id: "COLACT2", itemType: "action", relatedId: "COLACT2", label: "Collapse Repro Action Two", seconds: 180 }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+async function apiLogin(ctx: APIRequestContext): Promise<string> {
+  const res = await ctx.post(`${API}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  const uc = (body.userChurches || []).find((c: any) => c.church?.id === "CHU00000001") || body.userChurches?.[0];
+  expect(uc?.jwt).toBeTruthy();
+  return uc.jwt as string;
+}
+
+test.describe("issue-996 collapse expanded actions back to a section", () => {
+  let ctx: APIRequestContext;
+  let jwt: string;
+  let planId: string;
+
+  test.beforeAll(async () => {
+    ctx = await pwRequest.newContext();
+    jwt = await apiLogin(ctx);
+    const auth = { headers: { Authorization: "Bearer " + jwt } };
+
+    const planRes = await ctx.post(`${API}/doing/plans`, {
+      ...auth,
+      data: [
+        {
+          name: "Collapse Repro Plan",
+          serviceDate: "2030-05-01",
+          ministryId: "GRP0000000a",
+          planTypeId: "PLT00000001",
+          serviceOrder: true,
+          contentType: "venue",
+          contentId: "COLVENUE1"
+        }
+      ]
+    });
+    expect(planRes.ok()).toBeTruthy();
+    planId = (await planRes.json())[0].id;
+
+    const headerRes = await ctx.post(`${API}/doing/planItems`, {
+      ...auth,
+      data: [{ planId, sort: 1, itemType: "header", label: "Collapse Repro Header" }]
+    });
+    expect(headerRes.ok()).toBeTruthy();
+    const headerId = (await headerRes.json())[0].id;
+
+    const sectionRes = await ctx.post(`${API}/doing/planItems`, {
+      ...auth,
+      data: [
+        {
+          planId,
+          parentId: headerId,
+          sort: 1,
+          itemType: "providerSection",
+          relatedId: "COLSEC1",
+          label: "Collapse Repro Section",
+          providerId: "lessonschurch",
+          providerPath: "COLVENUE1",
+          providerContentPath: "0.0"
+        }
+      ]
+    });
+    expect(sectionRes.ok()).toBeTruthy();
+  });
+
+  test.afterAll(async () => {
+    if (planId) await ctx.delete(`${API}/doing/plans/${planId}`, { headers: { Authorization: "Bearer " + jwt } });
+    await ctx.dispose();
+  });
+
+  test("an expanded run offers a visible collapse control that restores the section", async ({ page }) => {
+    await page.route("**/providerProxy/getInstructions", (route) => route.fulfill({ json: INSTRUCTIONS }));
+    // No provider is linked locally; keep the dialog's direct provider call off the network.
+    await page.route("**/lessons.church/**", (route) => route.abort());
+
+    await page.goto(`/serving/plans/${planId}`);
+    await page.getByRole("tab", { name: "Service Order" }).click();
+
+    const sectionRow = page.locator(".planItem").filter({ hasText: "Collapse Repro Section" });
+    await expect(sectionRow).toHaveCount(1, { timeout: 15000 });
+    await sectionRow.click();
+
+    await page.getByRole("button", { name: "Expand to Actions" }).click();
+
+    const actionOne = page.locator(".planItem").filter({ hasText: "Collapse Repro Action One" });
+    const actionTwo = page.locator(".planItem").filter({ hasText: "Collapse Repro Action Two" });
+    await expect(actionOne).toHaveCount(1, { timeout: 15000 });
+    await expect(actionTwo).toHaveCount(1);
+    await expect(page.locator(".planItem").filter({ hasText: "Collapse Repro Section" })).toHaveCount(0);
+
+    // The bug: expansion was one-way, with no control anywhere to undo it.
+    const collapseButton = actionOne.locator('[data-testid="collapse-to-section-button"]');
+    await expect(collapseButton).toBeVisible({ timeout: 10000 });
+    await collapseButton.click();
+
+    await page.locator('[data-testid="confirm-collapse-dialog"]').getByRole("button", { name: "Collapse to Section" }).click();
+
+    await expect(page.locator(".planItem").filter({ hasText: "Collapse Repro Section" })).toHaveCount(1, { timeout: 15000 });
+    await expect(actionOne).toHaveCount(0);
+    await expect(actionTwo).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Adds a Collapse to Section button on a run of expanded lesson actions that puts the original section back. Scrolling in the lesson dialogs was already fixed on main.

Fixes ChurchApps/ChurchAppsSupport#996