### PR TITLE
Show the assigned volunteer next to order-of-service items

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2196,8 +2196,10 @@
       "enterSearch": "Enter search term",
       "includeInServices": "Include in services",
       "minutes": "Minutes",
+      "noPosition": "None",
       "planItemDescriptionAria": "Plan item description",
       "planItemNameAria": "Plan item name",
+      "position": "Position",
       "searchBoxAria": "searchBox",
       "seconds": "Seconds"
     },

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -154,6 +154,7 @@ export interface PlanItemInterface {
   providerPath?: string;
   providerContentPath?: string;
   thumbnailUrl?: string;
+  positionId?: string;
 
   children?: PlanItemInterface[];
 }

--- a/src/serving/components/PlanItem.tsx
+++ b/src/serving/components/PlanItem.tsx
@@ -33,6 +33,7 @@ interface Props {
   mediaLookup?: Record<string, ProviderMediaInfo>;
   /** Set on the first item of a run of actions expanded from one section, enabling the collapse control. */
   collapseItems?: PlanItemInterface[];
+  positionLabels?: Record<string, { text: string; assigned: boolean }>;
 }
 
 export const PlanItem = React.memo((props: Props) => {
@@ -157,7 +158,7 @@ export const PlanItem = React.memo((props: Props) => {
       const childStartTime = cumulativeTime;
       const childExcluded = c.itemType !== "header" && isChildExcluded(c.id || "");
       const childPlanItem = (
-        <PlanItem key={c.id} planItem={c} setEditPlanItem={props.setEditPlanItem} readOnly={props.readOnly} showItemDrop={props.showItemDrop} onDragChange={props.onDragChange} onChange={props.onChange} startTime={childStartTime} associatedContentPath={props.associatedContentPath} associatedProviderId={props.associatedProviderId} ministryId={props.ministryId} serviceTime={props.serviceTime} exclusions={props.exclusions} selectedServiceTimeId={props.selectedServiceTimeId} excluded={childExcluded} mediaLookup={props.mediaLookup} collapseItems={expandedRuns.get(c.id || "")} />
+        <PlanItem key={c.id} planItem={c} setEditPlanItem={props.setEditPlanItem} readOnly={props.readOnly} showItemDrop={props.showItemDrop} onDragChange={props.onDragChange} onChange={props.onChange} startTime={childStartTime} associatedContentPath={props.associatedContentPath} associatedProviderId={props.associatedProviderId} ministryId={props.ministryId} serviceTime={props.serviceTime} exclusions={props.exclusions} selectedServiceTimeId={props.selectedServiceTimeId} excluded={childExcluded} mediaLookup={props.mediaLookup} collapseItems={expandedRuns.get(c.id || "")} positionLabels={props.positionLabels} />
       );
       result.push(
         <React.Fragment key={c.id || `child-${index}`}>
@@ -193,6 +194,7 @@ export const PlanItem = React.memo((props: Props) => {
       startTime={props.startTime}
       serviceStartTime={props.serviceTime?.startTime}
       readOnly={props.readOnly}
+      positionLabel={props.planItem.positionId ? props.positionLabels?.[props.planItem.positionId] : undefined}
       onAddClick={(e) => setAnchorEl(e.currentTarget)}
       onEditClick={() => props.setEditPlanItem?.(props.planItem)}
       wrapRow={props.readOnly ? undefined : (row) => (
@@ -222,6 +224,7 @@ export const PlanItem = React.memo((props: Props) => {
       onDuplicateClick={handleDuplicate}
       onCollapseClick={showCollapse ? handleCollapseClick : undefined}
       mediaLookup={props.mediaLookup}
+      positionLabel={props.planItem.positionId ? props.positionLabels?.[props.planItem.positionId] : undefined}
     />
   );
 

--- a/src/serving/components/PlanItemEdit.tsx
+++ b/src/serving/components/PlanItemEdit.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { Box, Button, Checkbox, Chip, CircularProgress, Dialog, DialogTitle, DialogContent, DialogActions, DialogContentText, FormControl, FormControlLabel, FormGroup, Grid, InputLabel, List, ListItem, ListItemText, OutlinedInput, Stack, TextField, Typography } from "@mui/material";
+import { Box, Button, Checkbox, Chip, CircularProgress, Dialog, DialogTitle, DialogContent, DialogActions, DialogContentText, FormControl, FormControlLabel, FormGroup, Grid, InputLabel, List, ListItem, ListItemText, MenuItem, OutlinedInput, Select, Stack, TextField, Typography } from "@mui/material";
 import { Search as SearchIcon } from "@mui/icons-material";
 import { AppIconButton } from "../../components/ui/AppIconButton";
 import { type PlanItemInterface, type SongDetailInterface } from "../../helpers";
-import { type TimeInterface, type PlanItemTimeInterface } from "@churchapps/helpers";
+import { type TimeInterface, type PlanItemTimeInterface, type PositionInterface } from "@churchapps/helpers";
 import { ApiHelper, ArrayHelper, Locale } from "@churchapps/apphelper";
 import { shouldShowLabel, shouldShowDescription, shouldShowDuration, duplicatePlanItem } from "./planItemUtils";
 
 interface Props {
   planItem: PlanItemInterface;
+  positions?: PositionInterface[];
   onDone: () => void;
 }
 
@@ -296,6 +297,23 @@ export const PlanItemEdit = (props: Props) => {
                 />
               </Grid>
             </Grid>
+          )}
+          {(props.positions?.length || 0) > 0 && (
+            <FormControl fullWidth>
+              <InputLabel id="positionId-label">{Locale.label("plans.planItemEdit.position")}</InputLabel>
+              <Select
+                labelId="positionId-label"
+                label={Locale.label("plans.planItemEdit.position")}
+                value={(props.positions || []).some((p) => p.id === planItem?.positionId) ? planItem?.positionId || "" : ""}
+                onChange={(e) => setPlanItem({ ...planItem, positionId: e.target.value || undefined } as PlanItemInterface)}
+                data-testid="plan-item-position-select"
+              >
+                <MenuItem value="">{Locale.label("plans.planItemEdit.noPosition")}</MenuItem>
+                {(props.positions || []).map((p) => (
+                  <MenuItem key={p.id} value={p.id}>{p.categoryName ? `${p.categoryName} - ${p.name}` : p.name}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           )}
           {planItem?.itemType !== "header" && serviceTimes.length > 1 && (
             <Box>

--- a/src/serving/components/ServiceOrder.tsx
+++ b/src/serving/components/ServiceOrder.tsx
@@ -2,9 +2,9 @@ import React, { memo, useCallback, useMemo } from "react";
 import { Stack, Typography, Button, ButtonGroup, Box, Card, CardContent, Menu, MenuItem, Chip, Snackbar, Alert, TextField } from "@mui/material";
 import { Print as PrintIcon, Add as AddIcon, Album as AlbumIcon, MenuBook as MenuBookIcon, ArrowDropDown as ArrowDropDownIcon, Link as LinkIcon, Close as CloseIcon, Schedule as ScheduleIcon, BookmarkAdd as BookmarkAddIcon } from "@mui/icons-material";
 import { AppIconButton } from "../../components/ui/AppIconButton";
-import { type GroupInterface, type PlanInterface, type TimeInterface, type PlanItemTimeInterface } from "@churchapps/helpers";
+import { type GroupInterface, type PlanInterface, type TimeInterface, type PlanItemTimeInterface, type PositionInterface, type AssignmentInterface } from "@churchapps/helpers";
 import { type PlanItemInterface, hasPlansEditAccess } from "../../helpers";
-import { ApiHelper, Locale } from "@churchapps/apphelper";
+import { ApiHelper, ArrayHelper, Locale, type PersonInterface } from "@churchapps/apphelper";
 import { useQuery } from "@tanstack/react-query";
 import { getProvider, type InstructionItem, type IProvider } from "@churchapps/content-providers";
 import { PlanItemEdit } from "./PlanItemEdit";
@@ -16,7 +16,7 @@ import { LessonPreview } from "./LessonPreview";
 import { DraggableWrapper } from "../../components/DraggableWrapper";
 import { RowDropZone } from "./RowDropZone";
 import { formatTime } from "./PlanUtils";
-import { findThumbnailRecursive, buildProviderMediaLookup, matchProviderMedia, isVideoMedia, getVideoDuration, estimateSeconds, getProviderInstructions, type ProviderMediaInfo } from "./planItemUtils";
+import { findThumbnailRecursive, buildProviderMediaLookup, matchProviderMedia, isVideoMedia, getVideoDuration, estimateSeconds, getProviderInstructions, buildPositionLabels, type ProviderMediaInfo } from "./planItemUtils";
 
 interface Props {
   plan: PlanInterface;
@@ -79,6 +79,8 @@ export const ServiceOrder = memo((props: Props) => {
   const [showSaveTemplate, setShowSaveTemplate] = React.useState(false);
   const [mediaLookup, setMediaLookup] = React.useState<Record<string, ProviderMediaInfo>>({});
   const [settingTimes, setSettingTimes] = React.useState(false);
+  const [positions, setPositions] = React.useState<PositionInterface[]>([]);
+  const [positionLabels, setPositionLabels] = React.useState<Record<string, { text: string; assigned: boolean }>>({});
 
   // Get the provider dynamically based on plan's providerId
   const provider: IProvider | null = useMemo(() => {
@@ -105,6 +107,22 @@ export const ServiceOrder = memo((props: Props) => {
         setErrorMessage(Locale.label("plans.serviceOrder.loadError") || "Failed to load plan items");
         setPlanItems([]);
       }
+    }
+  }, [props.plan?.id]);
+
+  const loadPositions = useCallback(async () => {
+    if (!props.plan?.id) return;
+    try {
+      const [positionsData, assignmentsData]: [PositionInterface[], AssignmentInterface[]] = await Promise.all([
+        ApiHelper.get("/positions/plan/" + props.plan.id, "DoingApi"),
+        ApiHelper.get("/assignments/plan/" + props.plan.id, "DoingApi")
+      ]);
+      const peopleIds = ArrayHelper.getUniqueValues(assignmentsData || [], "personId");
+      const people: PersonInterface[] = peopleIds.length > 0 ? await ApiHelper.get("/people/ids?ids=" + peopleIds.join(","), "MembershipApi") : [];
+      setPositions(positionsData || []);
+      setPositionLabels(buildPositionLabels(positionsData || [], assignmentsData || [], people));
+    } catch (error) {
+      console.error("Error loading positions:", error);
     }
   }, [props.plan?.id]);
 
@@ -535,6 +553,7 @@ export const ServiceOrder = memo((props: Props) => {
                   selectedServiceTimeId={selectedServiceTimeId}
                   excluded={excluded}
                   mediaLookup={mediaLookup}
+                  positionLabels={positionLabels}
                 />
               </DraggableWrapper>
             </RowDropZone>
@@ -555,6 +574,7 @@ export const ServiceOrder = memo((props: Props) => {
               selectedServiceTimeId={selectedServiceTimeId}
               excluded={excluded}
               mediaLookup={mediaLookup}
+              positionLabels={positionLabels}
             />
           )}
         </React.Fragment>
@@ -601,6 +621,10 @@ export const ServiceOrder = memo((props: Props) => {
   }, [loadTimesAndExclusions]);
 
   React.useEffect(() => {
+    loadPositions();
+  }, [loadPositions]);
+
+  React.useEffect(() => {
     loadContentName();
   }, [loadContentName]);
 
@@ -614,6 +638,7 @@ export const ServiceOrder = memo((props: Props) => {
       {editPlanItem && canEdit && (
         <PlanItemEdit
           planItem={editPlanItem}
+          positions={positions}
           onDone={() => {
             setEditPlanItem(null);
             loadData();

--- a/src/serving/components/planItem/PlanItemHeader.tsx
+++ b/src/serving/components/planItem/PlanItemHeader.tsx
@@ -10,6 +10,7 @@ interface Props {
   startTime?: number;
   serviceStartTime?: Date;
   readOnly?: boolean;
+  positionLabel?: { text: string; assigned: boolean };
   onAddClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onEditClick: () => void;
   children?: React.ReactNode;
@@ -23,6 +24,7 @@ export const PlanItemHeader: React.FC<Props> = ({
   startTime = 0,
   serviceStartTime,
   readOnly,
+  positionLabel,
   onAddClick,
   onEditClick,
   children,
@@ -44,6 +46,15 @@ export const PlanItemHeader: React.FC<Props> = ({
         </Box>
       )}
       <Box component="span" sx={{ flex: 1 }}>{planItem.label}</Box>
+      {positionLabel?.text && (
+        <Box
+          component="span"
+          className="planItemPosition"
+          sx={{ flexShrink: 0, ml: 1.5, fontSize: "0.85rem", textAlign: "right", color: positionLabel.assigned ? "text.secondary" : "text.disabled", fontStyle: positionLabel.assigned ? "normal" : "italic" }}
+        >
+          {positionLabel.text}
+        </Box>
+      )}
       <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0, ml: 1.5 }}>
         {!readOnly && (
           <>

--- a/src/serving/components/planItem/PlanItemRow.tsx
+++ b/src/serving/components/planItem/PlanItemRow.tsx
@@ -19,6 +19,7 @@ interface Props {
   onDuplicateClick?: () => void;
   onCollapseClick?: () => void;
   mediaLookup?: Record<string, ProviderMediaInfo>;
+  positionLabel?: { text: string; assigned: boolean };
 }
 
 /**
@@ -34,7 +35,8 @@ export const PlanItemRow: React.FC<Props> = ({
   onEditClick,
   onDuplicateClick,
   onCollapseClick,
-  mediaLookup
+  mediaLookup,
+  positionLabel
 }) => {
   const railLabel = excluded ? "—" : (serviceStartTime ? formatClockTime(serviceStartTime, startTime) : formatTime(startTime));
   const providerMedia = planItem.thumbnailUrl ? undefined : matchProviderMedia(planItem, mediaLookup);
@@ -148,6 +150,15 @@ export const PlanItemRow: React.FC<Props> = ({
           </Box>
         )}
       </Box>
+      {positionLabel?.text && (
+        <Box
+          component="span"
+          className="planItemPosition"
+          sx={{ flexShrink: 0, ml: 1.5, fontSize: "0.85rem", textAlign: "right", color: positionLabel.assigned ? "text.secondary" : "text.disabled", fontStyle: positionLabel.assigned ? "normal" : "italic" }}
+        >
+          {positionLabel.text}
+        </Box>
+      )}
       <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0, ml: 1.5 }}>
         {!readOnly && (
           <>

--- a/src/serving/components/planItemUtils.ts
+++ b/src/serving/components/planItemUtils.ts
@@ -1,5 +1,6 @@
 import { type InstructionItem, type Instructions, type IProvider } from "@churchapps/content-providers";
-import { ApiHelper } from "@churchapps/apphelper";
+import { ApiHelper, type PersonInterface } from "@churchapps/apphelper";
+import { type AssignmentInterface, type PositionInterface } from "@churchapps/helpers";
 import { type PlanItemInterface, type FeedVenueInterface, type FeedSectionInterface, type FeedActionInterface } from "../../helpers";
 
 /** Gets instructions from a provider based on its capabilities, proxying through the API when auth is required. */
@@ -327,4 +328,22 @@ export function filterFeedByPlanItems(feed: FeedVenueInterface | null, planItems
     .filter((s: FeedSectionInterface) => sectionInPlan(s) || !!s.actions?.length);
 
   return { ...feed, sections };
+}
+
+export interface PositionLabel {
+  text: string;
+  assigned: boolean;
+}
+
+/** Maps each position id to the assigned volunteer name(s), falling back to the position name when nobody is assigned. */
+export function buildPositionLabels(positions: PositionInterface[], assignments: AssignmentInterface[], people: PersonInterface[]): Record<string, PositionLabel> {
+  const result: Record<string, PositionLabel> = {};
+  (positions || []).forEach((p) => {
+    const names = (assignments || [])
+      .filter((a) => a.positionId === p.id)
+      .map((a) => (people || []).find((person) => person.id === a.personId)?.name?.display)
+      .filter(Boolean);
+    if (p.id) result[p.id] = names.length > 0 ? { text: names.join(", "), assigned: true } : { text: p.name || "", assigned: false };
+  });
+  return result;
 }

--- a/src/serving/plans/PrintPlan.tsx
+++ b/src/serving/plans/PrintPlan.tsx
@@ -8,7 +8,7 @@ import { type PlanItemTimeInterface, type AssignmentInterface, type PlanInterfac
 import { OlfPrintPreview } from "../components/print/OlfPrintPreview";
 import { type FeedVenueInterface, type FeedSectionInterface, type FeedActionInterface } from "../../helpers";
 import { getProvider, type InstructionItem, type Instructions } from "@churchapps/content-providers";
-import { getProviderInstructions, filterFeedByPlanItems } from "../components/planItemUtils";
+import { getProviderInstructions, filterFeedByPlanItems, buildPositionLabels } from "../components/planItemUtils";
 
 export const PrintPlan = () => {
   const params = useParams();
@@ -230,6 +230,8 @@ export const PrintPlan = () => {
     return result;
   };
 
+  const positionLabels = React.useMemo(() => buildPositionLabels(positions, assignments, people), [positions, assignments, people]);
+
   // Per-column accumulators are mutated as the recursive renderer walks the tree.
   // Single-column fallback uses index 0; multi-column uses one entry per service time.
   const renderRows = () => {
@@ -261,6 +263,9 @@ export const PrintPlan = () => {
               {timeCells}
               <td style={Styles.tableCell}>
                 <b>{pi.label}:</b> {pi.description}
+                {plan?.showVolunteerNames && pi.positionId && positionLabels[pi.positionId]?.text && (
+                  <span style={{ float: "right", paddingLeft: 10, color: "#555" }}>{positionLabels[pi.positionId].text}</span>
+                )}
               </td>
               <td style={{ ...Styles.tableCell, textAlign: "right" }}>{formatTime(pi.seconds || 0)}</td>
             </tr>

--- a/tests/issue-988.spec.ts
+++ b/tests/issue-988.spec.ts
@@ -1,0 +1,86 @@
+import { request as pwRequest, type APIRequestContext } from "@playwright/test";
+import { loggedInTest as test, expect } from "./helpers/test-fixtures";
+
+// Issue #988: order-of-service items can reference one of the plan's positions so the
+// assigned volunteer's name shows beside the item on screen and in the printout.
+const API = "http://localhost:8084";
+const PERSON_ID = "PER00000001";
+const PERSON_NAME = "John Smith";
+
+async function apiLogin(ctx: APIRequestContext): Promise<string> {
+  const res = await ctx.post(`${API}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  const uc = (body.userChurches || []).find((c: any) => c.church?.id === "CHU00000001") || body.userChurches?.[0];
+  expect(uc?.jwt).toBeTruthy();
+  return uc.jwt as string;
+}
+
+test.describe("Serving - plan item positions", () => {
+  let ctx: APIRequestContext;
+  let jwt: string;
+  let planId: string;
+
+  test.beforeAll(async () => {
+    ctx = await pwRequest.newContext();
+    jwt = await apiLogin(ctx);
+    const auth = { headers: { Authorization: "Bearer " + jwt } };
+
+    const planRes = await ctx.post(`${API}/doing/plans`, {
+      ...auth,
+      data: [{ name: "Issue988 Position Repro", serviceDate: "2030-06-01", serviceOrder: true, showVolunteerNames: true }]
+    });
+    expect(planRes.ok()).toBeTruthy();
+    planId = (await planRes.json())[0].id;
+
+    const posRes = await ctx.post(`${API}/doing/positions`, {
+      ...auth,
+      data: [{ planId, categoryName: "Issue988 Team", name: "Issue988 Speaker", count: 1 }]
+    });
+    expect(posRes.ok()).toBeTruthy();
+    const positionId = (await posRes.json())[0].id;
+
+    const assignRes = await ctx.post(`${API}/doing/assignments`, {
+      ...auth,
+      data: [{ positionId, personId: PERSON_ID, status: "Accepted" }]
+    });
+    expect(assignRes.ok()).toBeTruthy();
+
+    const headerRes = await ctx.post(`${API}/doing/planItems`, {
+      ...auth,
+      data: [{ planId, sort: 1, itemType: "header", label: "Issue988 Section" }]
+    });
+    expect(headerRes.ok()).toBeTruthy();
+    const headerId = (await headerRes.json())[0].id;
+
+    const itemRes = await ctx.post(`${API}/doing/planItems`, {
+      ...auth,
+      data: [{ planId, parentId: headerId, sort: 1, itemType: "item", label: "Issue988 Sermon", seconds: 600 }]
+    });
+    expect(itemRes.ok()).toBeTruthy();
+  });
+
+  test.afterAll(async () => {
+    if (planId) await ctx.delete(`${API}/doing/plans/${planId}`, { headers: { Authorization: "Bearer " + jwt } });
+    await ctx.dispose();
+  });
+
+  test("assigning a position shows the volunteer beside the item and in print", async ({ page }) => {
+    await page.goto(`/serving/plans/${planId}`);
+    await page.getByRole("tab", { name: "Service Order" }).click({ timeout: 20000 });
+    await expect(page.getByText("Issue988 Sermon")).toBeVisible({ timeout: 20000 });
+
+    await page.getByRole("button", { name: "Edit Item" }).first().click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByTestId("plan-item-position-select").click();
+    await page.getByRole("option", { name: "Issue988 Team - Issue988 Speaker" }).click();
+    await dialog.getByRole("button", { name: "Save" }).click();
+
+    const row = page.locator(".planItem").filter({ hasText: "Issue988 Sermon" }).first();
+    await expect(row.locator(".planItemPosition")).toHaveText(PERSON_NAME, { timeout: 15000 });
+
+    await page.goto(`/serving/plans/print/${planId}`);
+    await expect(page.getByText("Issue988 Sermon")).toBeVisible({ timeout: 20000 });
+    await expect(page.locator("td").filter({ hasText: "Issue988 Sermon" }).first()).toContainText(PERSON_NAME);
+  });
+});


### PR DESCRIPTION
Order-of-service items (and section headers) can now point at one of the plan's positions, and the assigned volunteer's name shows beside the item in the Service Order tab and in the printout — so the run sheet answers "who is doing this" without cross-referencing the assignments roster. Depends on ChurchApps/Api#92 for the `positionId` column; B1Admin declares its own PlanItemInterface so no helpers bump is needed. Sibling UI PR: ChurchApps/B1App#515.

Fixes ChurchApps/ChurchAppsSupport#988