### PR TITLE
Fix gallery upload 403: send real content type/size

### DIFF
--- a/src/components/gallery/GalleryModal.tsx
+++ b/src/components/gallery/GalleryModal.tsx
@@ -43,11 +43,12 @@ export const GalleryModal: React.FC<Props> = (props: Props) => {
 
     setUploadError([]);
     try {
-      const fileName = Math.floor(Date.now() / 1000).toString() + ".jpg";
       const blob = FileHelper.dataURLtoBlob(dataUrl);
+      const extension = blob.type.split("/")[1] || "jpg";
+      const fileName = Math.floor(Date.now() / 1000).toString() + "." + extension;
       const file = new File([blob], fileName, { type: blob.type });
 
-      const params = { folder: aspectRatio.toString(), fileName };
+      const params = { folder: aspectRatio.toString(), fileName, contentType: blob.type, size: blob.size };
 
       const presigned = await ApiHelper.post("/gallery/requestUpload", params, "ContentApi");
       const doUpload = presigned.key !== undefined;


### PR DESCRIPTION
Part of #1008. GalleryModal always named uploads {epoch}.jpg regardless of the actual blob type (ImageEditor emits PNG), so the server's presigned POST Content-Type condition didn't match the uploaded bytes and S3 rejected the upload. Now derives the extension and passes contentType/size from the real blob to requestUpload.

Companion Api PR: fix/1008-gallery-content-type