### PR TITLE
Fix pickup add-form background ignoring dark mode

### DIFF
--- a/src/people/components/PickupPeople.tsx
+++ b/src/people/components/PickupPeople.tsx
@@ -97,7 +97,7 @@ export const PickupPeople: React.FC<Props> = (props) => {
   ));
 
   const addForm = adding && (
-    <Box sx={{ mt: 2, p: 2, backgroundColor: "grey.50", borderRadius: 1 }}>
+    <Box sx={{ mt: 2, p: 2, backgroundColor: "action.hover", borderRadius: 1 }}>
       <PersonAdd getPhotoUrl={PersonHelper.getPhotoUrl} addFunction={handleAddPerson} showCreatePersonOnNotFound={true} />
       <Typography variant="body2" color="text.secondary" sx={{ my: 1 }}>{Locale.label("people.pickup.orAddByName")}</Typography>
       <Stack spacing={2}>


### PR DESCRIPTION
#1005. The pickup add form used backgroundColor: grey.50, which stays near-white in dark mode. Switched to action.hover, which already tracks the theme elsewhere in B1Admin.

Left GalleryModal's delete-icon whitesmoke background alone — that's a scrim over an arbitrary photo thumbnail, not page chrome, so a fixed light color is the right call there regardless of app theme.