### PR TITLE
Click-to-edit script lines in the plan service order (#980)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2173,6 +2173,7 @@
     },
     "planItem": {
       "addItem": "Add Item",
+      "clickToAddText": "Click to add text",
       "collapseToSection": "Collapse to Section",
       "collapseToSectionConfirm": "Collapse these actions back into a single section? Any changes made to the individual actions will be lost.",
       "duration": "Duration",
@@ -2181,6 +2182,7 @@
       "expandToActions": "Expand to Actions",
       "externalItem": "External Item",
       "item": "Item",
+      "restoreOriginal": "Restore Original",
       "song": "Song"
     },
     "planItemEdit": {

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -145,6 +145,7 @@ export interface PlanItemInterface {
   parentId?: string;
   sort?: number;
   itemType?: string;
+  actionType?: string;
   relatedId?: string;
   label?: string;
   description?: string;

--- a/src/serving/components/PlanItem.tsx
+++ b/src/serving/components/PlanItem.tsx
@@ -45,7 +45,7 @@ export const PlanItem = React.memo((props: Props) => {
   const open = Boolean(anchorEl);
 
   // Use the expand hook for section expansion functionality
-  const { handleExpandToActions, canCollapse, handleCollapseToSection } = usePlanItemExpand({
+  const { handleExpandToActions, canCollapse, handleCollapseToSection, handleSaveDescription, handleRestoreOriginal } = usePlanItemExpand({
     planItem: props.planItem,
     associatedProviderId: props.associatedProviderId,
     associatedContentPath: props.associatedContentPath,
@@ -223,6 +223,8 @@ export const PlanItem = React.memo((props: Props) => {
       onEditClick={() => props.setEditPlanItem?.(props.planItem)}
       onDuplicateClick={handleDuplicate}
       onCollapseClick={showCollapse ? handleCollapseClick : undefined}
+      onSaveDescription={handleSaveDescription}
+      onRestoreOriginal={handleRestoreOriginal}
       mediaLookup={props.mediaLookup}
       positionLabel={props.planItem.positionId ? props.positionLabels?.[props.planItem.positionId] : undefined}
     />

--- a/src/serving/components/ServiceOrder.tsx
+++ b/src/serving/components/ServiceOrder.tsx
@@ -40,6 +40,7 @@ function instructionToPlanItem(item: InstructionItem, providerId?: string, provi
 
   return {
     itemType,
+    actionType: item.actionType,
     relatedId: item.relatedId,
     label: item.label || "",
     description: item.content,

--- a/src/serving/components/planItem/InlineEditableText.tsx
+++ b/src/serving/components/planItem/InlineEditableText.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { TextField } from "@mui/material";
+import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
+
+interface Props {
+  value: string;
+  onSave: (value: string) => void;
+  placeholder?: string;
+  "data-testid"?: string;
+}
+
+/** Click-to-edit text: renders as markdown until clicked, then a plain text field until blur/Enter. */
+export const InlineEditableText: React.FC<Props> = (props) => {
+  const [editing, setEditing] = React.useState(false);
+  const [text, setText] = React.useState(props.value);
+
+  React.useEffect(() => { if (!editing) setText(props.value); }, [props.value, editing]);
+
+  const save = () => {
+    setEditing(false);
+    if (text !== props.value) props.onSave(text);
+  };
+
+  if (editing) {
+    return (
+      <TextField
+        fullWidth
+        multiline
+        autoFocus
+        size="small"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={save}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); save(); }
+          if (e.key === "Escape") { setText(props.value); setEditing(false); }
+        }}
+        onClick={(e) => e.stopPropagation()}
+        data-testid={props["data-testid"]}
+      />
+    );
+  }
+
+  return (
+    <div
+      onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+      style={{ cursor: "text", minHeight: "1.5em" }}
+      data-testid={props["data-testid"]}
+    >
+      {props.value ? <MarkdownPreviewLight value={props.value} /> : <span style={{ opacity: 0.5 }}>{props.placeholder}</span>}
+    </div>
+  );
+};

--- a/src/serving/components/planItem/PlanItemRow.tsx
+++ b/src/serving/components/planItem/PlanItemRow.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon, UnfoldLess as UnfoldLessIcon } from "@mui/icons-material";
+import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon, UnfoldLess as UnfoldLessIcon, RestartAlt as RestartAltIcon } from "@mui/icons-material";
 import { Locale } from "@churchapps/apphelper";
 import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
 import { type PlanItemInterface } from "../../../helpers";
 import { formatTime, formatClockTime } from "../PlanUtils";
 import { PlanItemIcon } from "./PlanItemIcon";
+import { InlineEditableText } from "./InlineEditableText";
 import { type ProviderMediaInfo, matchProviderMedia, isVideoMedia, isAudioMedia, estimateSeconds } from "../planItemUtils";
+
+// Script lines (spoken/read text), as opposed to slide/media action types.
+const TEXT_ACTION_TYPES = new Set(["say", "do", "note"]);
 
 interface Props {
   planItem: PlanItemInterface;
@@ -18,6 +22,8 @@ interface Props {
   onEditClick: () => void;
   onDuplicateClick?: () => void;
   onCollapseClick?: () => void;
+  onSaveDescription?: (text: string) => void;
+  onRestoreOriginal?: () => void;
   mediaLookup?: Record<string, ProviderMediaInfo>;
   positionLabel?: { text: string; assigned: boolean };
 }
@@ -35,6 +41,8 @@ export const PlanItemRow: React.FC<Props> = ({
   onEditClick,
   onDuplicateClick,
   onCollapseClick,
+  onSaveDescription,
+  onRestoreOriginal,
   mediaLookup,
   positionLabel
 }) => {
@@ -47,11 +55,15 @@ export const PlanItemRow: React.FC<Props> = ({
   const storedSeconds = planItem.seconds ?? 0;
   const estimatedSeconds = storedSeconds === 0 ? estimateSeconds(planItem, mediaLookup) : 0;
   const isEstimate = estimatedSeconds > 0;
+  // Script lines edit inline; the row itself no longer opens the read-only dialog.
+  const isTextAction = !readOnly && !!onSaveDescription && TEXT_ACTION_TYPES.has(planItem.actionType || "");
+  const canRestore = isTextAction && !!onRestoreOriginal && !!planItem.providerId && !!planItem.providerPath && !!planItem.providerContentPath;
+  const rowClick = isTextAction ? undefined : onLabelClick;
   return (
     <Box
-      className={`planItem${onLabelClick ? " clickableRow" : ""}`}
-      sx={{ display: "flex", alignItems: "center", cursor: onLabelClick ? "pointer" : "default", opacity: excluded ? 0.5 : 1 }}
-      onClick={onLabelClick}
+      className={`planItem${rowClick ? " clickableRow" : ""}`}
+      sx={{ display: "flex", alignItems: "center", cursor: rowClick ? "pointer" : "default", opacity: excluded ? 0.5 : 1 }}
+      onClick={rowClick}
     >
       <div className="timeRailCell">
         <span className="timeRailLabel" style={excluded ? { color: "var(--text-muted)" } : undefined}>{railLabel}</span>
@@ -136,7 +148,16 @@ export const PlanItemRow: React.FC<Props> = ({
       </Box>
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <div>{planItem.label}</div>
-        {planItem.description && (
+        {isTextAction ? (
+          <Box className="planItemDescription" sx={{ clear: "both", width: "100%", pt: 0.5, fontSize: "0.9rem" }}>
+            <InlineEditableText
+              value={planItem.description || ""}
+              onSave={(text) => onSaveDescription?.(text)}
+              placeholder={Locale.label("plans.planItem.clickToAddText") || "Click to add text"}
+              data-testid="planItem-inline-text"
+            />
+          </Box>
+        ) : planItem.description && (
           <Box
             className="planItemDescription"
             sx={{
@@ -162,6 +183,20 @@ export const PlanItemRow: React.FC<Props> = ({
       <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0, ml: 1.5 }}>
         {!readOnly && (
           <>
+            {canRestore && (
+              <Box
+                component="button"
+                type="button"
+                className="actionButton rowControl"
+                data-testid="restore-original-button"
+                onClick={(e: React.MouseEvent) => { e.stopPropagation(); onRestoreOriginal?.(); }}
+                aria-label={Locale.label("plans.planItem.restoreOriginal") || "Restore original"}
+                title={Locale.label("plans.planItem.restoreOriginal") || "Restore original"}
+                sx={{ border: 0, cursor: "pointer", color: "primary.main", background: "transparent" }}
+              >
+                <RestartAltIcon />
+              </Box>
+            )}
             {onCollapseClick && (
               <Box
                 component="button"

--- a/src/serving/components/planItem/index.ts
+++ b/src/serving/components/planItem/index.ts
@@ -1,5 +1,6 @@
 export { PlanItemHeader } from "./PlanItemHeader";
 export { PlanItemRow } from "./PlanItemRow";
+export { InlineEditableText } from "./InlineEditableText";
 export { PlanItemIcon } from "./PlanItemIcon";
 export { ContentItemRow, type ContentItemData } from "./ContentItemRow";
 export { usePlanItemExpand } from "./usePlanItemExpand";

--- a/src/serving/components/planItem/usePlanItemExpand.ts
+++ b/src/serving/components/planItem/usePlanItemExpand.ts
@@ -21,6 +21,8 @@ interface ExpandResult {
   handleExpandToActions: () => Promise<void>;
   canCollapse: boolean;
   handleCollapseToSection: () => Promise<void>;
+  handleSaveDescription: (text: string) => Promise<void>;
+  handleRestoreOriginal: () => Promise<void>;
 }
 
 /** Expand a section plan item into its child action items via provider or plan-level association. */
@@ -50,8 +52,10 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
       parentId: planItem.parentId,
       sort: currentSort + (index + 1) / (count + 1),
       itemType: "providerPresentation",
+      actionType: action.actionType,
       relatedId: action.relatedId || action.id || "",
       label: action.label || "",
+      description: action.content || "",
       seconds: action.seconds || 0,
       providerId,
       providerPath,
@@ -188,11 +192,44 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
     }
   }, [collapseItems, ministryId, onChange, onError]);
 
+  const handleSaveDescription = useCallback(async (text: string) => {
+    await ApiHelper.post("/planItems", [{ ...planItem, description: text }], "DoingApi");
+    if (onChange) onChange();
+  }, [planItem, onChange]);
+
+  /** Re-resolves this single node from its provider path and overwrites the local edit — no stored-original copy needed. */
+  const handleRestoreOriginal = useCallback(async () => {
+    const { providerId, providerPath, providerContentPath } = planItem;
+    if (!providerId || !providerPath || !providerContentPath || !ministryId) return;
+
+    try {
+      const instructions: Instructions = await ApiHelper.post(
+        "/providerProxy/getInstructions",
+        { ministryId, providerId, path: providerPath },
+        "DoingApi"
+      );
+      if (!instructions?.items) return;
+
+      const found = planItem.relatedId ? findByRelatedId(instructions.items, planItem.relatedId) : null;
+      const node = found?.item || navigateToPath(instructions, providerContentPath);
+      if (!node) return;
+
+      const restored = { ...planItem, label: node.label || "", description: node.content || "", actionType: node.actionType };
+      await ApiHelper.post("/planItems", [restored], "DoingApi");
+      if (onChange) onChange();
+    } catch (error) {
+      console.error("Error restoring original content:", error);
+      if (onError) onError("Failed to restore original content");
+    }
+  }, [planItem, ministryId, onChange, onError]);
+
   return {
     isExpanding,
     canExpand,
     handleExpandToActions,
     canCollapse,
-    handleCollapseToSection
+    handleCollapseToSection,
+    handleSaveDescription,
+    handleRestoreOriginal
   };
 }


### PR DESCRIPTION
Replaces PR #463 (not merged — see review notes on that PR). Implements the plan in .notes/issues/980.md:

- Expand to Actions and section Customize both dropped `content`/`actionType` on the way from the provider into planItems, so script text existed nowhere to edit. Both are now persisted (companion Api PR).
- say/do/note rows render as click-to-edit inline text (click, type, blur/Enter to save) instead of opening the read-only ActionDialog.
- A Restore Original action re-resolves the single node from its provider path and overwrites the local edit — no new override-tracking column, matching the plan's provenance-only approach.
- Fixed a genuine dark-mode bug from the pattern the old PR used (no hardcoded backgroundColor: white).

Scope trim vs. the full plan doc: this does not make clicking an unexpanded section auto-run Expand to Actions — the existing explicit "Expand to Actions" button still does that step. Auto-expand-on-click is riskier UI surgery than the core data fix needed and can follow as a separate pass if wanted.

Print consistency is issue #979, not duplicated here.