### PR TITLE
Fix 1014 White boxes on dark mode on form level

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -71,14 +71,14 @@ export const Question: React.FC<Props> = memo((props) => {
 
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         py: 1.5,
         px: 2,
-        backgroundColor: "grey.50",
+        backgroundColor: theme.palette.mode === "dark" ? "grey.900" : "grey.50",
         borderRadius: 1,
         border: "1px solid",
-        borderColor: "grey.200"
-      }}>
+        borderColor: theme.palette.mode === "dark" ? "grey.800" : "grey.200"
+      })}>
       <Typography
         variant="subtitle2"
         sx={{


### PR DESCRIPTION
# Before
<img width="677" height="291" alt="image" src="https://github.com/user-attachments/assets/8ba3fc3e-55c9-485f-8eb0-3c9e5c77fd12" />

# After
<img width="967" height="346" alt="image" src="https://github.com/user-attachments/assets/9e622664-6c16-480b-a326-dce0a70ba5cb" />

https://github.com/ChurchApps/ChurchAppsSupport/issues/1014
