### PR TITLE
FIx notification preview issue on dark mode

### DIFF
--- a/src/groups/components/SendNotificationDialog.tsx
+++ b/src/groups/components/SendNotificationDialog.tsx
@@ -157,7 +157,7 @@ export const SendNotificationDialog: React.FC<Props> = (props) => {
           error={!imageUrlValid}
           helperText={!imageUrlValid ? "Use an https URL or leave this blank." : " "}
         />
-        <Paper variant="outlined" sx={{ p: 2, borderRadius: 1.5, bgcolor: "grey.50" }}>
+        <Paper variant="outlined" sx={{ p: 2, borderRadius: 1.5, bgcolor: (theme) => theme.palette.mode === "dark" ? "background.default" : "grey.50" }}>
           <Stack direction="row" spacing={1.5} alignItems="flex-start">
             <NotificationsActiveIcon sx={{ color: "primary.main", mt: 0.25 }} />
             <Box sx={{ minWidth: 0 }}>


### PR DESCRIPTION
# Before
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/220da4bf-ae41-4bfb-88f3-e67399bafc7a" />

# After
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ab18f362-f391-46b3-865a-cfead08c0a53" />

https://github.com/ChurchApps/ChurchAppsSupport/issues/1017