### PR TITLE
Send Plans breadcrumb to the plans list

### DIFF
--- a/src/serving/planTypes/PlanTypePage.tsx
+++ b/src/serving/planTypes/PlanTypePage.tsx
@@ -37,7 +37,7 @@ export const PlanTypePage = () => {
   }
 
   const breadcrumbItems: BreadcrumbItem[] = [
-    { label: Locale.label("components.wrapper.plans") || "Plans", path: "/serving" },
+    { label: Locale.label("components.wrapper.plans") || "Plans", path: "/serving/plans" },
     { label: planType.data.name || "" }
   ];
 

--- a/src/serving/plans/PlanPage.tsx
+++ b/src/serving/plans/PlanPage.tsx
@@ -54,7 +54,7 @@ export const PlanPage = () => {
     );
   }
 
-  const breadcrumbItems: BreadcrumbItem[] = [{ label: Locale.label("components.wrapper.plans") || "Plans", path: "/serving" }];
+  const breadcrumbItems: BreadcrumbItem[] = [{ label: Locale.label("components.wrapper.plans") || "Plans", path: "/serving/plans" }];
 
   if (planType) {
     breadcrumbItems.push({ label: planType.name || "", path: `/serving/planTypes/${planType.id}` });

--- a/tests/issue-1019.spec.ts
+++ b/tests/issue-1019.spec.ts
@@ -1,0 +1,19 @@
+import { loggedInTest as test, expect } from "./helpers/test-fixtures";
+
+// Issue #1019: Plans breadcrumb on a plan type / plan went to /serving (My Work)
+// because Authenticated.tsx redirects /serving → /serving/tasks.
+
+test("Plans breadcrumb goes to the plans list, not My Work", async ({ page }) => {
+  await page.goto("/serving/planTypes/PLT00000001");
+  await expect(page.locator(".MuiBreadcrumbs-root").getByRole("button", { name: /^Plans$/ })).toBeVisible({ timeout: 15000 });
+
+  await page.locator(".MuiBreadcrumbs-root").getByRole("button", { name: /^Plans$/ }).click();
+  await expect(page).toHaveURL(/\/serving\/plans(\/?$|\?)/, { timeout: 15000 });
+  await expect(page).not.toHaveURL(/\/serving\/tasks/);
+
+  await page.goto("/serving/plans/PLA00000001");
+  await expect(page.locator(".MuiBreadcrumbs-root").getByRole("button", { name: /^Plans$/ })).toBeVisible({ timeout: 15000 });
+  await page.locator(".MuiBreadcrumbs-root").getByRole("button", { name: /^Plans$/ }).click();
+  await expect(page).toHaveURL(/\/serving\/plans(\/?$|\?)/, { timeout: 15000 });
+  await expect(page).not.toHaveURL(/\/serving\/tasks/);
+});


### PR DESCRIPTION
Plans breadcrumbs on plan type and plan pages pointed at /serving, which redirects to My Work. They now go to /serving/plans.

https://github.com/ChurchApps/ChurchAppsSupport/issues/1019