### PR TITLE
Use dark-mode colors for group push preview

### DIFF
--- a/src/groups/components/SendNotificationDialog.tsx
+++ b/src/groups/components/SendNotificationDialog.tsx
@@ -157,7 +157,7 @@ export const SendNotificationDialog: React.FC<Props> = (props) => {
           error={!imageUrlValid}
           helperText={!imageUrlValid ? "Use an https URL or leave this blank." : " "}
         />
-        <Paper variant="outlined" sx={{ p: 2, borderRadius: 1.5, bgcolor: "grey.50" }}>
+        <Paper variant="outlined" sx={{ p: 2, borderRadius: 1.5, bgcolor: (theme) => theme.palette.mode === "dark" ? "background.default" : "grey.50" }}>
           <Stack direction="row" spacing={1.5} alignItems="flex-start">
             <NotificationsActiveIcon sx={{ color: "primary.main", mt: 0.25 }} />
             <Box sx={{ minWidth: 0 }}>

--- a/tests/issue-1017.spec.ts
+++ b/tests/issue-1017.spec.ts
@@ -1,0 +1,31 @@
+import { test as base, expect } from "@playwright/test";
+import { login } from "./helpers/auth";
+import { openSeedGroup } from "./helpers/fixtures";
+
+const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => localStorage.setItem("b1admin-theme-mode", "dark"));
+    await login(page);
+    await use(page);
+  }
+});
+
+function luminance(rgb: string) {
+  const m = rgb.match(/\d+/g)?.map(Number) || [255, 255, 255];
+  return 0.299 * m[0] + 0.587 * m[1] + 0.114 * m[2];
+}
+
+// Issue #1017: group push preview Paper uses grey.50 in dark mode.
+
+test("group push preview is not a light card in dark mode", async ({ page }) => {
+  await openSeedGroup(page);
+  await page.getByRole("button", { name: /Send push notification/i }).click();
+  const title = page.getByText("Notification title");
+  await expect(title).toBeVisible({ timeout: 15000 });
+  const bg = await title.evaluate((el) => {
+    let n: HTMLElement | null = el as HTMLElement;
+    while (n && !n.className.toString().includes("MuiPaper-root")) n = n.parentElement;
+    return n ? getComputedStyle(n).backgroundColor : "";
+  });
+  expect(luminance(bg), `expected a dark preview paper, got ${bg}`).toBeLessThan(80);
+});


### PR DESCRIPTION
The send-push dialog preview hardcoded grey.50, which stays near-white in dark mode.

https://github.com/ChurchApps/ChurchAppsSupport/issues/1017