### PR TITLE
Bulk-set a Yes/No custom field from the People list

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1533,7 +1533,11 @@
       "deleteConfirm": "Are you sure you want to delete {count} selected people? This action cannot be undone.",
       "deleting": "Deleting...",
       "deleteSuccess": "{count} people deleted successfully",
-      "deleteError": "Unable to delete selected people"
+      "deleteError": "Unable to delete selected people",
+      "customFieldTitle": "Set Custom Field",
+      "customField": "Custom Field",
+      "value": "Value",
+      "noCustomFields": "No Yes/No custom fields have been set up for people."
     },
     "demographics": {
       "age": "Age",

--- a/src/people/components/bulk/BulkCustomFieldDialog.tsx
+++ b/src/people/components/bulk/BulkCustomFieldDialog.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { ApiHelper, Locale } from "@churchapps/apphelper";
+import { type PersonFieldInterface } from "@churchapps/helpers";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, FormControl, InputLabel, Select, MenuItem, Typography } from "@mui/material";
+import { useBulkApplyDialog } from "./useBulkApplyDialog";
+import { type BulkResult } from "./BulkFieldDialog";
+
+interface Props {
+  open: boolean;
+  personIds: string[];
+  onClose: () => void;
+  onComplete: (result: BulkResult) => void;
+}
+
+export const BulkCustomFieldDialog: React.FC<Props> = (props) => {
+  const [fieldId, setFieldId] = React.useState("");
+  const [value, setValue] = React.useState("");
+
+  const { options, isSubmitting, handleApply } = useBulkApplyDialog<PersonFieldInterface>({
+    open: props.open,
+    onClose: props.onClose,
+    onComplete: props.onComplete,
+    onOpen: () => { setFieldId(""); setValue(""); },
+    // ponytail: Yes/No only — other types each need their own value editor. Add when asked.
+    loadOptions: async () => {
+      const fields: PersonFieldInterface[] = await ApiHelper.get("/personfields", "MembershipApi");
+      return (fields || []).filter((f) => f.fieldType === "Yes/No");
+    },
+    apply: async () => {
+      const payload = props.personIds.map((personId) => ({ personId, fieldId, value }));
+      await ApiHelper.post("/personfieldvalues", payload, "MembershipApi");
+      return {
+        message: Locale.label("people.bulk.fieldSuccess").replace("{count}", props.personIds.length.toString()),
+        severity: "success"
+      };
+    }
+  });
+
+  return (
+    <Dialog open={props.open} onClose={() => !isSubmitting && props.onClose()} maxWidth="xs" fullWidth>
+      <DialogTitle>{Locale.label("people.bulk.customFieldTitle")}</DialogTitle>
+      <DialogContent>
+        <Typography sx={{ mb: 2 }}>{Locale.label("people.bulk.fieldPrompt").replace("{count}", props.personIds.length.toString())}</Typography>
+        {options.length === 0
+          ? <Typography data-testid="bulk-custom-field-empty">{Locale.label("people.bulk.noCustomFields")}</Typography>
+          : (
+            <>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <InputLabel id="bulk-custom-field-label">{Locale.label("people.bulk.customField")}</InputLabel>
+                <Select labelId="bulk-custom-field-label" label={Locale.label("people.bulk.customField")} value={fieldId} onChange={(e) => setFieldId(e.target.value)} data-testid="bulk-custom-field-select">
+                  {options.map((f) => <MenuItem key={f.id} value={f.id}>{f.name}</MenuItem>)}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth>
+                <InputLabel id="bulk-custom-value-label">{Locale.label("people.bulk.value")}</InputLabel>
+                <Select labelId="bulk-custom-value-label" label={Locale.label("people.bulk.value")} value={value} onChange={(e) => setValue(e.target.value)} data-testid="bulk-custom-value-select">
+                  <MenuItem value="True">{Locale.label("common.yes")}</MenuItem>
+                  <MenuItem value="False">{Locale.label("common.no")}</MenuItem>
+                </Select>
+              </FormControl>
+            </>
+          )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose} variant="outlined" disabled={isSubmitting}>{Locale.label("common.cancel")}</Button>
+        <Button onClick={handleApply} variant="contained" disabled={isSubmitting || !fieldId || !value} data-testid="bulk-custom-field-apply">{Locale.label("people.bulk.apply")}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/people/components/bulk/PeopleBulkActions.tsx
+++ b/src/people/components/bulk/PeopleBulkActions.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { Locale } from "@churchapps/apphelper";
 import { useCampuses } from "../../../hooks/useCampuses";
 import { Button, Menu, MenuItem, Divider, ListItemIcon, ListItemText } from "@mui/material";
-import { ExpandMore as ExpandMoreIcon, HowToReg as StatusIcon, Favorite as MaritalIcon, Wc as GenderIcon, MailLock as OptOutIcon, GroupAdd as GroupAddIcon, GroupRemove as GroupRemoveIcon, Delete as DeleteIcon, Business as CampusIcon, ViewKanban as WorkflowIcon } from "@mui/icons-material";
+import { ExpandMore as ExpandMoreIcon, HowToReg as StatusIcon, Favorite as MaritalIcon, Wc as GenderIcon, MailLock as OptOutIcon, GroupAdd as GroupAddIcon, GroupRemove as GroupRemoveIcon, Delete as DeleteIcon, Business as CampusIcon, ViewKanban as WorkflowIcon, RuleFolder as CustomFieldIcon } from "@mui/icons-material";
 import { BulkFieldDialog, type BulkFieldOption, type BulkResult } from "./BulkFieldDialog";
 import { BulkGroupDialog } from "./BulkGroupDialog";
 import { BulkWorkflowDialog } from "./BulkWorkflowDialog";
+import { BulkCustomFieldDialog } from "./BulkCustomFieldDialog";
 import { getMembershipStatusOptions } from "../../helpers/MembershipStatusOptions";
 
 interface FieldConfig {
@@ -27,6 +28,7 @@ export const PeopleBulkActions: React.FC<Props> = (props) => {
   const [fieldConfig, setFieldConfig] = React.useState<FieldConfig | null>(null);
   const [groupMode, setGroupMode] = React.useState<"add" | "remove" | null>(null);
   const [showWorkflow, setShowWorkflow] = React.useState(false);
+  const [showCustomField, setShowCustomField] = React.useState(false);
   const campuses = useCampuses();
   const campusOptions: BulkFieldOption[] = React.useMemo(
     () => campuses.filter((c) => c.id).map((c) => ({ value: c.id as string, label: c.name || "" })),
@@ -117,6 +119,10 @@ export const PeopleBulkActions: React.FC<Props> = (props) => {
             <ListItemText>{Locale.label(menuLabels[config.field])}</ListItemText>
           </MenuItem>
         ))}
+        <MenuItem onClick={() => { setShowCustomField(true); closeMenu(); }} data-testid="bulk-action-custom-field">
+          <ListItemIcon><CustomFieldIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>{Locale.label("people.bulk.customFieldTitle")}</ListItemText>
+        </MenuItem>
         <Divider />
         <MenuItem onClick={() => openGroup("add")} data-testid="bulk-action-add-group">
           <ListItemIcon><GroupAddIcon fontSize="small" /></ListItemIcon>
@@ -157,6 +163,15 @@ export const PeopleBulkActions: React.FC<Props> = (props) => {
           mode={groupMode}
           personIds={props.selectedPersonIds}
           onClose={() => setGroupMode(null)}
+          onComplete={props.onComplete}
+        />
+      )}
+
+      {showCustomField && (
+        <BulkCustomFieldDialog
+          open={showCustomField}
+          personIds={props.selectedPersonIds}
+          onClose={() => setShowCustomField(false)}
           onComplete={props.onComplete}
         />
       )}

--- a/tests/bulk-custom-field.spec.ts
+++ b/tests/bulk-custom-field.spec.ts
@@ -6,8 +6,8 @@ import { confirmDelete } from "./helpers/fixtures";
 
 // Issue #1015: select people in the People list, then Actions > Set Custom Field
 // to set a Yes/No custom field on all of them at once.
-const FIELD_NAME = "Zz Playwright Newsletter";
 const SUFFIX = Date.now().toString();
+const FIELD_NAME = `Zz Newsletter ${SUFFIX}`;
 const LAST_NAME = `BulkCustom${SUFFIX}`;
 const PEOPLE = [
   { first: "Priscilla", last: LAST_NAME, email: `bulk-custom-a-${SUFFIX}@example.com` },
@@ -27,9 +27,10 @@ test.describe.serial("Bulk custom field (#1015)", () => {
 
   test.afterAll(async () => {
     await page.goto("/settings/custom-fields").catch(() => { });
-    const row = page.locator('[data-testid^="custom-field-row-"]').filter({ hasText: FIELD_NAME }).first();
-    if (await row.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await row.click();
+    // Also sweeps fields left behind by earlier retried runs.
+    const rows = page.locator('[data-testid^="custom-field-row-"]').filter({ hasText: /Zz (Playwright )?Newsletter/ });
+    while (await rows.first().isVisible({ timeout: 3000 }).catch(() => false)) {
+      await rows.first().click();
       await page.locator("#customFieldBox").getByRole("button", { name: "Delete" }).click().catch(() => { });
       await confirmDelete(page).catch(() => { });
       await page.locator("#customFieldBox").waitFor({ state: "hidden", timeout: 10000 }).catch(() => { });
@@ -75,7 +76,7 @@ test.describe.serial("Bulk custom field (#1015)", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: 10000 });
     await dialog.getByTestId("bulk-custom-field-select").click();
-    await page.getByRole("option", { name: FIELD_NAME }).click();
+    await page.getByRole("option", { name: FIELD_NAME, exact: true }).click();
     await dialog.getByTestId("bulk-custom-value-select").click();
     await page.getByRole("option", { name: "Yes", exact: true }).click();
 

--- a/tests/bulk-custom-field.spec.ts
+++ b/tests/bulk-custom-field.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, chromium, type Browser, type Page } from "@playwright/test";
+import { login } from "./helpers/auth";
+import { STORAGE_STATE_PATH } from "./global-setup";
+import { navigateToPeople } from "./helpers/navigation";
+import { confirmDelete } from "./helpers/fixtures";
+
+// Issue #1015: select people in the People list, then Actions > Set Custom Field
+// to set a Yes/No custom field on all of them at once.
+const FIELD_NAME = "Zz Playwright Newsletter";
+const SUFFIX = Date.now().toString();
+const LAST_NAME = `BulkCustom${SUFFIX}`;
+const PEOPLE = [
+  { first: "Priscilla", last: LAST_NAME, email: `bulk-custom-a-${SUFFIX}@example.com` },
+  { first: "Aquila", last: LAST_NAME, email: `bulk-custom-b-${SUFFIX}@example.com` }
+];
+
+test.describe.serial("Bulk custom field (#1015)", () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    browser = await chromium.launch();
+    const ctx = await browser.newContext({ storageState: STORAGE_STATE_PATH });
+    page = await ctx.newPage();
+    await login(page);
+  });
+
+  test.afterAll(async () => {
+    await page.goto("/settings/custom-fields").catch(() => { });
+    const row = page.locator('[data-testid^="custom-field-row-"]').filter({ hasText: FIELD_NAME }).first();
+    if (await row.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await row.click();
+      await page.locator("#customFieldBox").getByRole("button", { name: "Delete" }).click().catch(() => { });
+      await confirmDelete(page).catch(() => { });
+      await page.locator("#customFieldBox").waitFor({ state: "hidden", timeout: 10000 }).catch(() => { });
+    }
+    await browser.close();
+  });
+
+  test("setup: a Yes/No custom field and two people", async () => {
+    test.slow();
+    await page.goto("/settings/custom-fields");
+    await page.locator('[data-testid="add-custom-field-button"], [data-testid="add-custom-field-button-empty"]').first().click();
+    await page.locator('[data-testid="custom-field-name-input"] input').fill(FIELD_NAME);
+    await page.locator('[data-testid="custom-field-type-select"]').click();
+    await page.getByRole("option", { name: "Yes/No" }).click();
+    await page.locator("#customFieldBox").getByRole("button", { name: "Save" }).click();
+    await expect(page.locator('[data-testid^="custom-field-row-"]').filter({ hasText: FIELD_NAME }).first()).toBeVisible({ timeout: 10000 });
+
+    for (const person of PEOPLE) {
+      await navigateToPeople(page);
+      await page.locator('[name="first"]').fill(person.first);
+      await page.locator('[name="last"]').fill(person.last);
+      await page.locator('[name="email"]').fill(person.email);
+      await page.locator('[type="submit"]').click();
+      await page.waitForURL(/\/people\/[^/]+/, { timeout: 20000 });
+    }
+  });
+
+  test("sets the field on every selected person", async () => {
+    test.slow();
+    await navigateToPeople(page);
+    await page.locator('input[name="searchText"]').fill(LAST_NAME);
+    await page.waitForResponse((r) => r.url().includes("/people/advancedSearch") && r.status() === 200, { timeout: 20000 });
+
+    const rows = page.locator("table tbody tr").filter({ hasText: LAST_NAME });
+    await expect(rows).toHaveCount(2, { timeout: 20000 });
+    for (const person of PEOPLE) {
+      await page.locator("table tbody tr").filter({ hasText: `${person.first} ${LAST_NAME}` }).first().getByRole("checkbox").check();
+    }
+
+    await page.getByTestId("bulk-actions-button").click();
+    await page.getByTestId("bulk-action-custom-field").click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+    await dialog.getByTestId("bulk-custom-field-select").click();
+    await page.getByRole("option", { name: FIELD_NAME }).click();
+    await dialog.getByTestId("bulk-custom-value-select").click();
+    await page.getByRole("option", { name: "Yes", exact: true }).click();
+
+    const saved = page.waitForResponse((r) => r.url().includes("/personfieldvalues") && r.request().method() === "POST" && r.status() === 200, { timeout: 20000 });
+    await dialog.getByTestId("bulk-custom-field-apply").click();
+    await saved;
+    await expect(dialog).toHaveCount(0, { timeout: 10000 });
+
+    for (const person of PEOPLE) {
+      await navigateToPeople(page);
+      await page.locator('input[name="searchText"]').fill(LAST_NAME);
+      await page.waitForResponse((r) => r.url().includes("/people/advancedSearch") && r.status() === 200, { timeout: 20000 });
+      await page.locator("table tbody tr").filter({ hasText: `${person.first} ${LAST_NAME}` }).first().getByRole("link").first().click();
+      await page.waitForURL(/\/people\/[^/]+/, { timeout: 20000 });
+      await expect(page.getByText(FIELD_NAME, { exact: true })).toBeVisible({ timeout: 20000 });
+      await expect(page.getByText(FIELD_NAME, { exact: true }).locator("xpath=following-sibling::b[1]")).toHaveText("Yes", { timeout: 20000 });
+    }
+  });
+});


### PR DESCRIPTION
Closes ChurchApps/ChurchAppsSupport#1015.

You can now select people in the People list and use Actions > Set Custom Field to set a Yes/No custom field (like "Newsletter") on all of them at once. It posts to the existing `/personfieldvalues` endpoint, which already upserts a batch, so there's no API change needed.

Only Yes/No fields are offered for now — the other field types each need their own value editor. Covered by `tests/bulk-custom-field.spec.ts`.
