### PR TITLE
Enhancements/b1 dark theme

### DIFF
--- a/src/calendars/AvailabilityPage.tsx
+++ b/src/calendars/AvailabilityPage.tsx
@@ -160,7 +160,29 @@ export const AvailabilityPage = () => {
         </HeaderPrimaryButton>
       </PageHeader>
       <Box sx={{ p: 3 }}>
-        <Box sx={{ bgcolor: "background.paper", p: 2, borderRadius: 2, border: "1px solid", borderColor: "grey.200" }}>
+        <Box sx={{
+          bgcolor: "background.paper",
+          p: 2,
+          borderRadius: 2,
+          border: "1px solid",
+          borderColor: "grey.200",
+          "& .rbc-btn-group button": {
+            color: (theme) => theme.palette.mode === "dark" ? "text.primary" : "inherit"
+          },
+          "& .rbc-btn-group button:hover, & .rbc-btn-group button:focus, & .rbc-btn-group button:active, & .rbc-btn-group button.rbc-active": {
+            color: (theme) => theme.palette.mode === "dark" ? "#000 !important" : "inherit",
+            backgroundColor: (theme) => theme.palette.mode === "dark" ? "#e0e0e0 !important" : undefined
+          },
+          "& .rbc-toolbar-label": {
+            color: (theme) => theme.palette.mode === "dark" ? "text.primary" : "inherit"
+          },
+          "& .rbc-off-range-bg": {
+            backgroundColor: (theme) => theme.palette.mode === "dark" ? theme.palette.action.hover : undefined
+          },
+          "& .rbc-today": {
+            backgroundColor: (theme) => theme.palette.mode === "dark" ? theme.palette.action.selected : undefined
+          }
+        }}>
           <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
             <TextField select size="small" label={Locale.label("calendars.availability.filter")} value={filter} onChange={(e) => setFilter(e.target.value)} sx={{ minWidth: 240 }} data-testid="availability-filter" SelectProps={{ displayEmpty: true }}>
               <MenuItem value="">{Locale.label("calendars.availability.allRoomsResources")}</MenuItem>

--- a/src/calendars/components/CuratedEventCalendar.tsx
+++ b/src/calendars/components/CuratedEventCalendar.tsx
@@ -141,12 +141,18 @@ export function CuratedEventCalendar(props: Props) {
         "& .rbc-btn-group button": {
           color: (theme) => theme.palette.mode === "dark" ? "text.primary" : "inherit"
         },
-        "& .rbc-btn-group button.rbc-active": {
-          color: (theme) => theme.palette.mode === "dark" ? "#000" : "inherit",
-          backgroundColor: (theme) => theme.palette.mode === "dark" ? "#e0e0e0" : undefined
+        "& .rbc-btn-group button:hover, & .rbc-btn-group button:focus, & .rbc-btn-group button:active, & .rbc-btn-group button.rbc-active": {
+          color: (theme) => theme.palette.mode === "dark" ? "#000 !important" : "inherit",
+          backgroundColor: (theme) => theme.palette.mode === "dark" ? "#e0e0e0 !important" : undefined
         },
         "& .rbc-toolbar-label": {
           color: (theme) => theme.palette.mode === "dark" ? "text.primary" : "inherit"
+        },
+        "& .rbc-off-range-bg": {
+          backgroundColor: (theme) => theme.palette.mode === "dark" ? theme.palette.action.hover : undefined
+        },
+        "& .rbc-today": {
+          backgroundColor: (theme) => theme.palette.mode === "dark" ? theme.palette.action.selected : undefined
         }
       }}>
         <Calendar

--- a/src/groups/components/GroupMembers.tsx
+++ b/src/groups/components/GroupMembers.tsx
@@ -432,7 +432,7 @@ export const GroupMembers: React.FC<Props> = memo((props) => {
         mb: 2.5,
         borderRadius: 1.5,
         borderColor: "divider",
-        bgcolor: "grey.50"
+        bgcolor: (theme) => theme.palette.mode === "dark" ? "background.default" : "grey.50"
       }}>
       <Stack spacing={1.75}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">

--- a/src/groups/components/SendEmailDialog.tsx
+++ b/src/groups/components/SendEmailDialog.tsx
@@ -96,7 +96,11 @@ export const SendEmailDialog: React.FC<Props> = (props) => {
     previewHtml = previewHtml.replace(/\{\{displayName\}\}/g, "John Smith");
     previewHtml = previewHtml.replace(/\{\{email\}\}/g, "john@example.com");
     previewHtml = previewHtml.replace(/\{\{churchName\}\}/g, churchName);
-    return previewHtml;
+    
+    const isDarkTheme = document.body.classList.contains("dark-theme");
+    const styleInjection = isDarkTheme ? "<style>body { color: white; font-family: sans-serif; }</style>" : "<style>body { font-family: sans-serif; }</style>";
+    
+    return previewHtml + styleInjection;
   };
 
   const getPreviewSubject = () => {

--- a/src/sermons/components/TabEdit.tsx
+++ b/src/sermons/components/TabEdit.tsx
@@ -210,7 +210,7 @@ export const TabEdit: React.FC<Props> = (props) => {
                         alignItems: "center",
                         justifyContent: "center",
                         color: "primary.main",
-                        backgroundColor: "#fff",
+                        backgroundColor: "background.paper",
                         cursor: "pointer",
                         "&:hover": {
                           borderColor: "primary.main",
@@ -284,7 +284,7 @@ export const TabEdit: React.FC<Props> = (props) => {
           </Stack>
         </DialogContent>
 
-        <DialogActions sx={{ p: 3, backgroundColor: "grey.50" }}>
+        <DialogActions sx={{ p: 3 }}>
           <Stack direction="row" spacing={2} sx={{ width: "100%" }}>
             {currentTab?.id && (
               <Button

--- a/src/serving/songs/components/SongDetailLinks.tsx
+++ b/src/serving/songs/components/SongDetailLinks.tsx
@@ -81,7 +81,8 @@ export const SongDetailLinks = memo((props: Props) => {
             "&:hover": {
               transform: "translateY(-2px)",
               boxShadow: 2
-            }
+            },
+            backgroundColor: "#FFF"
           }}
           component="a"
           href={/^https?:\/\//i.test(link.url || "") || /^mailto:/i.test(link.url || "") ? link.url : "#"}
@@ -95,7 +96,7 @@ export const SongDetailLinks = memo((props: Props) => {
                 alt={link.service}
                 style={{
                   maxHeight: 40,
-                  maxWidth: 40,
+                  maxWidth: 60,
                   objectFit: "contain"
                 }}
               />

--- a/src/serving/tasks/workflows/components/TriggerExecutionsPanel.tsx
+++ b/src/serving/tasks/workflows/components/TriggerExecutionsPanel.tsx
@@ -53,7 +53,7 @@ export const TriggerExecutionsPanel: React.FC<Props> = (props) => {
   };
 
   return (
-    <Box sx={{ mt: 3, backgroundColor: 'white', padding: 2, borderRadius: 2 }} data-testid="trigger-executions-panel">
+    <Box sx={{ mt: 3, backgroundColor: "background.paper", padding: 2, borderRadius: 2 }} data-testid="trigger-executions-panel">
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
         <Typography variant="subtitle2">{Locale.label("tasks.executions.title")}</Typography>
         <AppIconButton label={Locale.label("tasks.executions.refresh")} icon={<RefreshIcon />} data-testid="refresh-executions" onClick={load} />

--- a/src/settings/components/EmailTemplateEdit.tsx
+++ b/src/settings/components/EmailTemplateEdit.tsx
@@ -110,7 +110,11 @@ export const EmailTemplateEdit: React.FC<Props> = ({ template, onSave, onCancel,
     preview = preview.replace(/\{\{displayName\}\}/g, "John Smith");
     preview = preview.replace(/\{\{email\}\}/g, "john@example.com");
     preview = preview.replace(/\{\{churchName\}\}/g, churchName);
-    return preview;
+    
+    const isDarkTheme = document.body.classList.contains("dark-theme");
+    const styleInjection = isDarkTheme ? "<style>body { color: white; font-family: sans-serif; }</style>" : "<style>body { font-family: sans-serif; }</style>";
+    
+    return preview + styleInjection;
   };
 
   const getPreviewSubject = () => {

--- a/src/site/components/AppearanceEdit.tsx
+++ b/src/site/components/AppearanceEdit.tsx
@@ -230,7 +230,7 @@ export function AppearanceEdit(props: Props) {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <CardWithHeader title={Locale.label("site.appearanceEdit.logoManagement")} icon={<ImageIcon />}>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>{Locale.label("site.appearanceEdit.logoUploadDescription")}</Typography>
 

--- a/src/site/components/CssEdit.tsx
+++ b/src/site/components/CssEdit.tsx
@@ -104,7 +104,7 @@ a:hover {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <Alert severity="warning" icon={<WarningIcon />} sx={{ mb: 3 }}>
           <Typography variant="body2"><strong>{Locale.label("site.cssEdit.advancedFeature")}</strong> {Locale.label("site.cssEdit.advancedFeatureDescription")}</Typography>
         </Alert>

--- a/src/site/components/FontEdit.tsx
+++ b/src/site/components/FontEdit.tsx
@@ -98,7 +98,7 @@ export function FontEdit(props: Props) {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <CardWithHeader title={Locale.label("site.fontEdit.fontSelection")} icon={<StyleIcon />}>
           <Grid container spacing={3}>
             <Grid size={{ xs: 12, md: 6 }}>

--- a/src/site/components/NavStyleEdit.tsx
+++ b/src/site/components/NavStyleEdit.tsx
@@ -124,7 +124,7 @@ export function NavStyleEdit(props: Props) {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <CardWithHeader title={Locale.label("site.navStyleEdit.solidSection")} icon={<MenuIcon />}>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>{Locale.label("site.navStyleEdit.solidSectionDesc")}</Typography>
           <Grid container spacing={2}>

--- a/src/site/components/PaletteEdit.tsx
+++ b/src/site/components/PaletteEdit.tsx
@@ -166,7 +166,7 @@ export function PaletteEdit(props: Props) {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <CardWithHeader title={Locale.label("site.paletteEdit.colorValues")} icon={<ColorLensIcon />}>
           <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2, color: "text.primary" }}>{Locale.label("site.paletteEdit.baseColors")}</Typography>
           <Grid container spacing={2} sx={{ mb: 3 }}>

--- a/src/site/components/SpacingScaleEdit.tsx
+++ b/src/site/components/SpacingScaleEdit.tsx
@@ -112,7 +112,7 @@ export function SpacingScaleEdit(props: Props) {
           </Grid>
         </CardWithHeader>
 
-        <Box sx={{ mt: 3 }}>
+        <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "var(--border-main)", borderTop: "none" }}>
           <CardWithHeader title={Locale.label("site.spacingScaleEdit.practicalExamples")} icon={<VisibilityIcon />}>
             <Box sx={{ p: 3, backgroundColor: "var(--bg-sub)", borderRadius: 2 }}>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
@@ -125,12 +125,12 @@ export function SpacingScaleEdit(props: Props) {
                 borderRadius: 2,
                 p: `${spacing.sm}px`,
                 mb: 4,
-                backgroundColor: "#fff",
+                backgroundColor: "background.paper",
                 display: "flex",
                 gap: `${spacing.xs}px`
               }}>
                 {["A", "B", "C", "D", "E"].map((letter) => (
-                  <Box key={letter} sx={{ width: 32, height: 32, backgroundColor: "grey.200", borderRadius: 1, display: "flex", alignItems: "center", justifyContent: "center", fontSize: "0.875rem", fontWeight: 600 }}>{letter}</Box>
+                  <Box key={letter} sx={{ width: 32, height: 32, backgroundColor: "action.selected", borderRadius: 1, display: "flex", alignItems: "center", justifyContent: "center", fontSize: "0.875rem", fontWeight: 600 }}>{letter}</Box>
                 ))}
               </Box>
               <Typography variant="caption" color="text.secondary" sx={{ mt: -3, mb: 4, display: "block" }}>
@@ -143,7 +143,7 @@ export function SpacingScaleEdit(props: Props) {
                 borderRadius: 2,
                 p: `${spacing.md}px`,
                 mb: 4,
-                backgroundColor: "#fff"
+                backgroundColor: "background.paper"
               }}>
                 <Typography variant="h6" sx={{ mb: `${spacing.sm}px` }}>{Locale.label("site.spacingScaleEdit.cardTitle")}</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: `${spacing.md}px` }}>
@@ -151,7 +151,7 @@ export function SpacingScaleEdit(props: Props) {
                 </Typography>
                 <Stack direction="row" spacing={`${spacing.sm}px`}>
                   <Box sx={{ px: 2, py: 1, backgroundColor: "primary.main", color: "#fff", borderRadius: 1, fontSize: "0.875rem" }}>{Locale.label("site.spacingScaleEdit.buttonOne")}</Box>
-                  <Box sx={{ px: 2, py: 1, backgroundColor: "grey.300", borderRadius: 1, fontSize: "0.875rem" }}>{Locale.label("site.spacingScaleEdit.buttonTwo")}</Box>
+                  <Box sx={{ px: 2, py: 1, backgroundColor: "action.disabledBackground", color: "text.primary", borderRadius: 1, fontSize: "0.875rem" }}>{Locale.label("site.spacingScaleEdit.buttonTwo")}</Box>
                 </Stack>
               </Box>
 

--- a/src/site/components/SpacingScaleEdit.tsx
+++ b/src/site/components/SpacingScaleEdit.tsx
@@ -88,7 +88,7 @@ export function SpacingScaleEdit(props: Props) {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <CardWithHeader title={Locale.label("site.spacingScaleEdit.spacingValues")} icon={<SpaceBarIcon />}>
           <Grid container spacing={3}>
             {spacingItems.map((item) => (

--- a/src/site/components/TypographyEdit.tsx
+++ b/src/site/components/TypographyEdit.tsx
@@ -78,7 +78,7 @@ export function TypographyEdit(props: Props) {
         </Stack>
       </Box>
 
-      <Box sx={{ p: 3, backgroundColor: "#FFF", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
+      <Box sx={{ p: 3, backgroundColor: "background.paper", borderRadius: "0 0 12px 12px", border: "1px solid", borderColor: "grey.200", borderTop: "none" }}>
         <CardWithHeader title={Locale.label("site.typographyEdit.typographyScale")} icon={<FormatSizeIcon />}>
           <Grid container spacing={3}>
             <Grid size={{ xs: 12, md: 4 }}>


### PR DESCRIPTION
# Theme Improvements
* Fixed the email preview section in the Written Email dialog. In dark mode, the message/letter text was difficult to read due to dark text on a dark background. This has now been resolved.
* `http://localhost:3101/groups/IJxdi7A79Tl` — On the `Send a message to members section`, the dark theme caused readability issues with the UI on the white container. This has now been resolved.
* On /site/appearance → Spacing Scale, the “See how your spacing values affect real UI elements” section has white boxes that are difficult to read. The spacing information inside them needs better contrast and should be fixed.
* The dark theme issue in the Calendars and Availability Calendars has now been resolved.
* Fixed the white static colors in the Site Appearance section.
* Black container on song detail screen like (praisecharts..etc...)


# Before
<img width="961" height="560" alt="image" src="https://github.com/user-attachments/assets/8444e41c-7863-48b4-9f9d-9a0ffa3863b1" />
<img width="1440" height="410" alt="image" src="https://github.com/user-attachments/assets/154b2a62-430e-4716-8d90-34d1ebd584c4" />


# After
<img width="966" height="564" alt="image" src="https://github.com/user-attachments/assets/6e89cbde-a07a-4de5-8b5a-c5068fa276d4" />
<img width="1440" height="496" alt="Screenshot 2026-08-26 at 2 55 03 PM" src="https://github.com/user-attachments/assets/c52dadd6-11ac-4ea5-a024-fcc55e1019db" />
