### PR TITLE
Revert plan section folders (#1009)

### DIFF
--- a/public/css/all.css
+++ b/public/css/all.css
@@ -495,7 +495,7 @@ label .description {
   opacity: 0;
   transition: opacity 0.15s;
 }
-.planItemHeader .actionButton.alwaysVisible, .planItem .actionButton.alwaysVisible {
+.planItemHeader .actionButton.alwaysVisible {
   opacity: 1;
 }
 .planItem:hover .dragHandle, .planItemHeader:hover .dragHandle,

--- a/src/serving/components/PlanItem.tsx
+++ b/src/serving/components/PlanItem.tsx
@@ -8,7 +8,7 @@ import { type TimeInterface, type PlanItemTimeInterface } from "@churchapps/help
 import { ApiHelper, Locale } from "@churchapps/apphelper";
 import { SongDialog } from "./SongDialog";
 import { LessonDialog } from "./LessonDialog";
-import { getNextChildSort, treeSeconds, duplicatePlanItem, findExpandedRuns, type ProviderMediaInfo } from "./planItemUtils";
+import { getNextChildSort, estimateSeconds, duplicatePlanItem, findExpandedRuns, type ProviderMediaInfo } from "./planItemUtils";
 import { ActionDialog } from "./ActionDialog";
 import { ActionSelector } from "./ActionSelector";
 import { PlanItemHeader, PlanItemRow } from "./planItem/index";
@@ -42,10 +42,7 @@ export const PlanItem = React.memo((props: Props) => {
   const [lessonSectionId, setLessonSectionId] = React.useState<string | null>(null);
   const [actionId, setActionId] = React.useState<string | null>(null);
   const [showActionSelector, setShowActionSelector] = React.useState(false);
-  const [folderCollapsed, setFolderCollapsed] = React.useState(false);
   const open = Boolean(anchorEl);
-  const isHeader = props.planItem.itemType === "header";
-  const isFolder = !isHeader && (props.planItem.children?.length || 0) > 0;
 
   // Use the expand hook for section expansion functionality
   const { handleExpandToActions, canCollapse, handleCollapseToSection, handleSaveDescription, handleRestoreOriginal } = usePlanItemExpand({
@@ -149,10 +146,9 @@ export const PlanItem = React.memo((props: Props) => {
     return (props.exclusions || []).some((ex) => ex.planItemId === childId && ex.timeId === props.selectedServiceTimeId && ex.excluded);
   };
 
-  // Legacy sibling runs live directly under headers; a folder's children are never a run.
   const expandedRuns = React.useMemo(
-    () => (props.readOnly || !isHeader ? new Map<string, PlanItemInterface[]>() : findExpandedRuns(props.planItem.children || [])),
-    [props.planItem.children, props.readOnly, isHeader]
+    () => (props.readOnly ? new Map<string, PlanItemInterface[]>() : findExpandedRuns(props.planItem.children || [])),
+    [props.planItem.children, props.readOnly]
   );
 
   const getChildren = () => {
@@ -187,7 +183,7 @@ export const PlanItem = React.memo((props: Props) => {
           )}
         </React.Fragment>
       );
-      if (!childExcluded) cumulativeTime += treeSeconds(c, props.mediaLookup);
+      if (!childExcluded) cumulativeTime += estimateSeconds(c, props.mediaLookup);
     });
     return result;
   };
@@ -217,26 +213,21 @@ export const PlanItem = React.memo((props: Props) => {
   );
 
   const getGenericRow = (onLabelClick?: () => void) => (
-    <>
-      <PlanItemRow
-        planItem={props.planItem}
-        startTime={props.startTime}
-        serviceStartTime={props.serviceTime?.startTime}
-        excluded={props.excluded}
-        readOnly={props.readOnly}
-        onLabelClick={onLabelClick}
-        onEditClick={() => props.setEditPlanItem?.(props.planItem)}
-        onDuplicateClick={handleDuplicate}
-        onCollapseClick={showCollapse ? handleCollapseClick : undefined}
-        folderCollapsed={isFolder ? folderCollapsed : undefined}
-        onToggleFolder={isFolder ? () => setFolderCollapsed((v) => !v) : undefined}
-        onSaveDescription={handleSaveDescription}
-        onRestoreOriginal={handleRestoreOriginal}
-        mediaLookup={props.mediaLookup}
-        positionLabel={props.planItem.positionId ? props.positionLabels?.[props.planItem.positionId] : undefined}
-      />
-      {isFolder && !folderCollapsed && <div className="planItemChildren" style={{ paddingLeft: 32 }}>{getChildren()}</div>}
-    </>
+    <PlanItemRow
+      planItem={props.planItem}
+      startTime={props.startTime}
+      serviceStartTime={props.serviceTime?.startTime}
+      excluded={props.excluded}
+      readOnly={props.readOnly}
+      onLabelClick={onLabelClick}
+      onEditClick={() => props.setEditPlanItem?.(props.planItem)}
+      onDuplicateClick={handleDuplicate}
+      onCollapseClick={showCollapse ? handleCollapseClick : undefined}
+      onSaveDescription={handleSaveDescription}
+      onRestoreOriginal={handleRestoreOriginal}
+      mediaLookup={props.mediaLookup}
+      positionLabel={props.planItem.positionId ? props.positionLabels?.[props.planItem.positionId] : undefined}
+    />
   );
 
   const getPlanItem = () => {
@@ -290,7 +281,7 @@ export const PlanItem = React.memo((props: Props) => {
           sectionName={props.planItem.label}
           onClose={() => setLessonSectionId(null)}
           onExpandToActions={
-            !props.readOnly && !isFolder && (
+            !props.readOnly && (
               (props.associatedContentPath && props.planItem.relatedId) ||
               (props.planItem.providerId && props.planItem.providerPath && props.planItem.providerContentPath)
             )

--- a/src/serving/components/planItem/PlanItemRow.tsx
+++ b/src/serving/components/planItem/PlanItemRow.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon, UnfoldLess as UnfoldLessIcon, RestartAlt as RestartAltIcon, ExpandMore as ExpandMoreIcon, ChevronRight as ChevronRightIcon } from "@mui/icons-material";
+import { DragIndicator as DragIndicatorIcon, Edit as EditIcon, Schedule as ScheduleIcon, ContentCopy as ContentCopyIcon, MusicNote as MusicNoteIcon, UnfoldLess as UnfoldLessIcon, RestartAlt as RestartAltIcon } from "@mui/icons-material";
 import { Locale } from "@churchapps/apphelper";
 import { MarkdownPreviewLight } from "@churchapps/apphelper/markdown";
 import { type PlanItemInterface } from "../../../helpers";
 import { formatTime, formatClockTime } from "../PlanUtils";
 import { PlanItemIcon } from "./PlanItemIcon";
 import { InlineEditableText } from "./InlineEditableText";
-import { type ProviderMediaInfo, matchProviderMedia, isVideoMedia, isAudioMedia, estimateSeconds, treeSeconds } from "../planItemUtils";
+import { type ProviderMediaInfo, matchProviderMedia, isVideoMedia, isAudioMedia, estimateSeconds } from "../planItemUtils";
 
 // Script lines (spoken/read text), as opposed to slide/media action types.
 const TEXT_ACTION_TYPES = new Set(["say", "do", "note"]);
@@ -22,9 +22,6 @@ interface Props {
   onEditClick: () => void;
   onDuplicateClick?: () => void;
   onCollapseClick?: () => void;
-  /** Set when the item is a folder (section with nested actions). */
-  folderCollapsed?: boolean;
-  onToggleFolder?: () => void;
   onSaveDescription?: (text: string) => void;
   onRestoreOriginal?: () => void;
   mediaLookup?: Record<string, ProviderMediaInfo>;
@@ -44,21 +41,18 @@ export const PlanItemRow: React.FC<Props> = ({
   onEditClick,
   onDuplicateClick,
   onCollapseClick,
-  folderCollapsed,
-  onToggleFolder,
   onSaveDescription,
   onRestoreOriginal,
   mediaLookup,
   positionLabel
 }) => {
-  const isFolder = !!onToggleFolder;
   const railLabel = excluded ? "—" : (serviceStartTime ? formatClockTime(serviceStartTime, startTime) : formatTime(startTime));
   const providerMedia = planItem.thumbnailUrl ? undefined : matchProviderMedia(planItem, mediaLookup);
   const showVideoThumb = !!providerMedia && isVideoMedia(planItem.label, providerMedia);
   const showAudioIcon = !!providerMedia && isAudioMedia(planItem.label, providerMedia);
   // Untimed images show a planning estimate (~5:00) rather than an alarming 0:00 —
   // stored seconds stay 0 so playback leaves the volunteer in control.
-  const storedSeconds = isFolder ? treeSeconds(planItem, mediaLookup) : planItem.seconds ?? 0;
+  const storedSeconds = planItem.seconds ?? 0;
   const estimatedSeconds = storedSeconds === 0 ? estimateSeconds(planItem, mediaLookup) : 0;
   const isEstimate = estimatedSeconds > 0;
   // Script lines edit inline; the row itself no longer opens the read-only dialog.
@@ -84,20 +78,6 @@ export const PlanItemRow: React.FC<Props> = ({
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
           <DragIndicatorIcon />
-        </Box>
-      )}
-      {isFolder && (
-        <Box
-          component="button"
-          type="button"
-          className="actionButton alwaysVisible"
-          data-testid="folder-toggle-button"
-          aria-expanded={!folderCollapsed}
-          aria-label={folderCollapsed ? Locale.label("common.expand") : Locale.label("common.collapse")}
-          onClick={(e: React.MouseEvent) => { e.stopPropagation(); onToggleFolder?.(); }}
-          sx={{ border: 0, cursor: "pointer", color: "text.secondary", background: "transparent", display: "inline-flex", p: 0, mr: 0.5 }}
-        >
-          {folderCollapsed ? <ChevronRightIcon /> : <ExpandMoreIcon />}
         </Box>
       )}
       <Box sx={{ width: 80, height: 45, mr: 1, flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>

--- a/src/serving/components/planItem/usePlanItemExpand.ts
+++ b/src/serving/components/planItem/usePlanItemExpand.ts
@@ -25,9 +25,7 @@ interface ExpandResult {
   handleRestoreOriginal: () => Promise<void>;
 }
 
-/** Expand a section plan item into nested child action items via provider or plan-level association.
- * The section row stays as a folder; collapse is a view toggle. handleCollapseToSection only serves
- * legacy sibling runs created before folders existed. */
+/** Expand a section plan item into its child action items via provider or plan-level association. */
 export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
   const { planItem, associatedProviderId, associatedContentPath, ministryId, collapseItems, onChange, onError } = options;
   const [isExpanding, setIsExpanding] = useState(false);
@@ -46,11 +44,13 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
   ): Partial<PlanItemInterface>[] => {
     if (!section.children || section.children.length === 0) return [];
 
-    // The section stays and becomes a folder; actions nest beneath it.
+    // Fractional sorts keep the new items in the deleted section's slot without
+    // colliding with later siblings; a /planItems/sort call renumbers afterward.
+    const count = section.children.length;
     return section.children.map((action, index) => ({
       planId: planItem.planId,
-      parentId: planItem.id,
-      sort: currentSort + index + 1,
+      parentId: planItem.parentId,
+      sort: currentSort + (index + 1) / (count + 1),
       itemType: "providerPresentation",
       actionType: action.actionType,
       relatedId: action.relatedId || action.id || "",
@@ -62,10 +62,17 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
       providerContentPath: `${pathPrefix}.${index}`,
       thumbnailUrl: findThumbnailRecursive(action)
     }));
-  }, [planItem.planId, planItem.id]);
+  }, [planItem.planId, planItem.parentId]);
+
+  const replaceSectionWith = useCallback(async (actionItems: Partial<PlanItemInterface>[]) => {
+    // Post replacement items first to preserve original if post fails.
+    const saved = await ApiHelper.post("/planItems", actionItems, "DoingApi");
+    await ApiHelper.delete(`/planItems/${planItem.id}`, "DoingApi");
+    if (saved?.[0]) await ApiHelper.post("/planItems/sort", saved[0], "DoingApi");
+  }, [planItem.id]);
 
   const expandViaProvider = useCallback(async () => {
-    const { providerId, providerPath, providerContentPath } = planItem;
+    const { providerId, providerPath, providerContentPath, sort } = planItem;
     if (!providerId || !providerPath || !providerContentPath || !ministryId) return;
 
     const instructions: Instructions = await ApiHelper.post(
@@ -82,9 +89,16 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
     const pathPrefix = found?.path || providerContentPath;
     if (!section?.children || section.children.length === 0) return;
 
-    const actionItems = createActionItems(section, pathPrefix, providerId, providerPath, planItem.children?.length || 0);
-    if (actionItems.length > 0) await ApiHelper.post("/planItems", actionItems, "DoingApi");
-  }, [planItem, ministryId, createActionItems]);
+    const actionItems = createActionItems(
+      section,
+      pathPrefix,
+      providerId,
+      providerPath,
+      sort || 1
+    );
+
+    if (actionItems.length > 0) await replaceSectionWith(actionItems);
+  }, [planItem, ministryId, createActionItems, replaceSectionWith]);
 
   const expandViaPlan = useCallback(async () => {
     if (!associatedProviderId || !associatedContentPath || !ministryId || !planItem.relatedId) return;
@@ -100,9 +114,16 @@ export function usePlanItemExpand(options: ExpandOptions): ExpandResult {
     const found = findByRelatedId(instructions.items, planItem.relatedId);
     if (!found || !found.item.children || found.item.children.length === 0) return;
 
-    const actionItems = createActionItems(found.item, found.path, associatedProviderId, associatedContentPath, planItem.children?.length || 0);
-    if (actionItems.length > 0) await ApiHelper.post("/planItems", actionItems, "DoingApi");
-  }, [planItem, associatedProviderId, associatedContentPath, ministryId, createActionItems]);
+    const actionItems = createActionItems(
+      found.item,
+      found.path,
+      associatedProviderId,
+      associatedContentPath,
+      planItem.sort || 1
+    );
+
+    if (actionItems.length > 0) await replaceSectionWith(actionItems);
+  }, [planItem, associatedProviderId, associatedContentPath, ministryId, createActionItems, replaceSectionWith]);
 
   const handleExpandToActions = useCallback(async () => {
     if (!canExpand) {

--- a/src/serving/components/planItemUtils.ts
+++ b/src/serving/components/planItemUtils.ts
@@ -124,17 +124,11 @@ export const ESTIMATED_IMAGE_SECONDS = 300;
 
 /** Effective seconds for schedule math: stored value, else the image planning estimate. */
 export function estimateSeconds(planItem: PlanItemInterface, lookup?: Record<string, ProviderMediaInfo>): number {
-  // A section expanded into child actions is a folder: its children carry the time.
-  if (planItem.itemType === "header" || (planItem.children?.length || 0) > 0) return 0;
   if (planItem.seconds && planItem.seconds > 0) return planItem.seconds;
+  if (planItem.itemType === "header") return 0;
   const media = matchProviderMedia(planItem, lookup);
   if (media && !isVideoMedia(planItem.label, media) && !isAudioMedia(planItem.label, media)) return ESTIMATED_IMAGE_SECONDS;
   return 0;
-}
-
-/** estimateSeconds for an item plus all of its descendants. */
-export function treeSeconds(planItem: PlanItemInterface, lookup?: Record<string, ProviderMediaInfo>): number {
-  return estimateSeconds(planItem, lookup) + (planItem.children || []).reduce((sum, c) => sum + treeSeconds(c, lookup), 0);
 }
 
 /** Older provider versions omit mediaType, so also sniff the file extension from the label/url. */
@@ -310,8 +304,7 @@ export function filterFeedByPlanItems(feed: FeedVenueInterface | null, planItems
   const norm = (s?: string) => (s || "").trim().toLowerCase();
   const flat = flattenPlanItems(planItems);
 
-  // A section with nested actions is a folder: its surviving children decide what prints, not the section.
-  const sectionItems = flat.filter(pi => SECTION_PLAN_TYPES.has(pi.itemType || "") && !pi.children?.length);
+  const sectionItems = flat.filter(pi => SECTION_PLAN_TYPES.has(pi.itemType || ""));
   const sectionIds = new Set(sectionItems.map(pi => pi.relatedId).filter(Boolean));
   const sectionNames = new Set(sectionItems.map(pi => norm(pi.label || pi.description)).filter(Boolean));
 

--- a/src/serving/plans/PrintPlan.tsx
+++ b/src/serving/plans/PrintPlan.tsx
@@ -243,12 +243,10 @@ export const PrintPlan = () => {
       let rows: JSX.Element[] = [];
       items.forEach((pi) => {
         if (pi.itemType !== "header") {
-          const isFolder = (pi.children?.length || 0) > 0;
-          const seconds = isFolder ? 0 : pi.seconds || 0;
           const timeCells: JSX.Element[] = [];
           if (serviceTimes.length === 0) {
             timeCells.push(<td key="t0" style={Styles.tableCell}>{formatTime(accumulators[0])}</td>);
-            accumulators[0] += seconds;
+            accumulators[0] += pi.seconds || 0;
           } else {
             serviceTimes.forEach((st, i) => {
               const excluded = isExcluded(pi.id || "", st.id || "");
@@ -256,7 +254,7 @@ export const PrintPlan = () => {
                 timeCells.push(<td key={st.id} style={{ ...Styles.tableCell, color: "#999" }}>—</td>);
               } else {
                 timeCells.push(<td key={st.id} style={Styles.tableCell}>{formatClockTime(st.startTime, accumulators[i])}</td>);
-                accumulators[i] += seconds;
+                accumulators[i] += pi.seconds || 0;
               }
             });
           }
@@ -269,7 +267,7 @@ export const PrintPlan = () => {
                   <span style={{ float: "right", paddingLeft: 10, color: "#555" }}>{positionLabels[pi.positionId].text}</span>
                 )}
               </td>
-              <td style={{ ...Styles.tableCell, textAlign: "right" }}>{isFolder ? "" : formatTime(seconds)}</td>
+              <td style={{ ...Styles.tableCell, textAlign: "right" }}>{formatTime(pi.seconds || 0)}</td>
             </tr>
           );
         }

--- a/tests/issue-996-collapse.spec.ts
+++ b/tests/issue-996-collapse.spec.ts
@@ -1,10 +1,9 @@
 import { request as pwRequest, type APIRequestContext } from "@playwright/test";
 import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 
-// Issues #996 / #1009: "Expand to Actions" nests the actions under the section (a folder) instead of
-// replacing it, so collapsing is a view toggle and per-action edits survive. The plan is seeded
-// through DoingApi and the provider is mocked at the API proxy, since no content provider is linked
-// in the local stack.
+// Issue #996 (fix 2): "Expand to Actions" permanently rewrote the plan with no way back.
+// The plan is seeded through DoingApi and the provider is mocked at the API proxy, since
+// no content provider is linked in the local stack.
 const API = "http://localhost:8084";
 
 const INSTRUCTIONS = {
@@ -24,7 +23,7 @@ const INSTRUCTIONS = {
           content: "Section notes",
           seconds: 300,
           children: [
-            { id: "COLACT1", itemType: "action", actionType: "say", relatedId: "COLACT1", label: "Collapse Repro Action One", content: "Original line", seconds: 120 },
+            { id: "COLACT1", itemType: "action", relatedId: "COLACT1", label: "Collapse Repro Action One", seconds: 120 },
             { id: "COLACT2", itemType: "action", relatedId: "COLACT2", label: "Collapse Repro Action Two", seconds: 180 }
           ]
         }
@@ -42,7 +41,7 @@ async function apiLogin(ctx: APIRequestContext): Promise<string> {
   return uc.jwt as string;
 }
 
-test.describe("issue-996 / #1009 expanded sections are collapsible folders", () => {
+test.describe("issue-996 collapse expanded actions back to a section", () => {
   let ctx: APIRequestContext;
   let jwt: string;
   let planId: string;
@@ -86,12 +85,10 @@ test.describe("issue-996 / #1009 expanded sections are collapsible folders", () 
           itemType: "providerSection",
           relatedId: "COLSEC1",
           label: "Collapse Repro Section",
-          seconds: 300,
           providerId: "lessonschurch",
           providerPath: "COLVENUE1",
           providerContentPath: "0.0"
-        },
-        { planId, parentId: headerId, sort: 2, itemType: "item", label: "Collapse Repro After", seconds: 60 }
+        }
       ]
     });
     expect(sectionRes.ok()).toBeTruthy();
@@ -102,7 +99,7 @@ test.describe("issue-996 / #1009 expanded sections are collapsible folders", () 
     await ctx.dispose();
   });
 
-  test("expand keeps the section as a folder; collapse hides actions without losing edits", async ({ page }) => {
+  test("an expanded run offers a visible collapse control that restores the section", async ({ page }) => {
     await page.route("**/providerProxy/getInstructions", (route) => route.fulfill({ json: INSTRUCTIONS }));
     // No provider is linked locally; keep the dialog's direct provider call off the network.
     await page.route("**/lessons.church/**", (route) => route.abort());
@@ -113,43 +110,24 @@ test.describe("issue-996 / #1009 expanded sections are collapsible folders", () 
     const sectionRow = page.locator(".planItem").filter({ hasText: "Collapse Repro Section" });
     await expect(sectionRow).toHaveCount(1, { timeout: 15000 });
     await sectionRow.click();
+
     await page.getByRole("button", { name: "Expand to Actions" }).click();
 
     const actionOne = page.locator(".planItem").filter({ hasText: "Collapse Repro Action One" });
     const actionTwo = page.locator(".planItem").filter({ hasText: "Collapse Repro Action Two" });
     await expect(actionOne).toHaveCount(1, { timeout: 15000 });
     await expect(actionTwo).toHaveCount(1);
-    await expect(sectionRow).toHaveCount(1);
+    await expect(page.locator(".planItem").filter({ hasText: "Collapse Repro Section" })).toHaveCount(0);
 
-    // Folder time is the sum of its children (300), not double-counted: the next item starts at 5:00.
-    const afterRow = page.locator(".planItem").filter({ hasText: "Collapse Repro After" });
-    await expect(afterRow.locator(".timeRailLabel")).toHaveText("5:00");
+    // The bug: expansion was one-way, with no control anywhere to undo it.
+    const collapseButton = actionOne.locator('[data-testid="collapse-to-section-button"]');
+    await expect(collapseButton).toBeVisible({ timeout: 10000 });
+    await collapseButton.click();
 
-    // Already a folder: the dialog no longer offers to expand again.
-    await sectionRow.click();
-    await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Expand to Actions" })).toHaveCount(0);
-    await page.getByRole("button", { name: "Close" }).click();
+    await page.locator('[data-testid="confirm-collapse-dialog"]').getByRole("button", { name: "Collapse to Section" }).click();
 
-    // Edit an action inline, then collapse and re-expand the folder.
-    await actionOne.getByTestId("planItem-inline-text").click();
-    await actionOne.getByTestId("planItem-inline-text").locator("textarea").first().fill("Edited line");
-    await actionOne.getByTestId("planItem-inline-text").locator("textarea").first().press("Enter");
-    await expect(actionOne).toContainText("Edited line", { timeout: 10000 });
-
-    const toggle = sectionRow.getByTestId("folder-toggle-button");
-    await toggle.click();
+    await expect(page.locator(".planItem").filter({ hasText: "Collapse Repro Section" })).toHaveCount(1, { timeout: 15000 });
     await expect(actionOne).toHaveCount(0);
     await expect(actionTwo).toHaveCount(0);
-    await expect(sectionRow).toHaveCount(1);
-
-    await toggle.click();
-    await expect(actionOne).toHaveCount(1);
-    await expect(actionOne).toContainText("Edited line");
-
-    // Survives a reload: nothing was deleted or recreated.
-    await page.reload();
-    await page.getByRole("tab", { name: "Service Order" }).click();
-    await expect(page.locator(".planItem").filter({ hasText: "Collapse Repro Action One" })).toContainText("Edited line", { timeout: 15000 });
   });
 });


### PR DESCRIPTION
Reverts #484. Going back to the flat expand-to-actions behavior instead of nesting into collapsible folders.