### PR TITLE
Bug Fixes

### DIFF
--- a/src/groups/components/ServiceTimesEdit.tsx
+++ b/src/groups/components/ServiceTimesEdit.tsx
@@ -3,7 +3,7 @@ import { type GroupInterface, type GroupServiceTimeInterface, type ServiceInterf
 import { ApiHelper, Locale } from "@churchapps/apphelper";
 import {
   Table, TableBody, TableRow, TableCell, FormControl, InputLabel, Select, MenuItem, type SelectChangeEvent,
-  Icon
+  Icon, Snackbar, Alert
 } from "@mui/material";
 import { PersonRemove as PersonRemoveIcon, Add as AddIcon } from "@mui/icons-material";
 import { useCampuses } from "../../hooks/useCampuses";
@@ -21,6 +21,7 @@ export const ServiceTimesEdit = memo((props: Props) => {
   const [serviceTimes, setServiceTimes] = React.useState<ServiceTimeInterface[]>([]);
   const [services, setServices] = React.useState<ServiceInterface[]>([]);
   const [addServiceTimeId, setAddServiceTimeId] = React.useState("");
+  const [errorToast, setErrorToast] = React.useState("");
 
   const loadData = useCallback(() => {
     ApiHelper.get("/groupservicetimes?groupId=" + props.group.id, "AttendanceApi").then((data: any) => setGroupServiceTimes(data));
@@ -71,10 +72,18 @@ export const ServiceTimesEdit = memo((props: Props) => {
   const handleAdd = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
+      if (!addServiceTimeId) return;
+
+      const exists = groupServiceTimes.some(gst => gst.serviceTimeId === addServiceTimeId);
+      if (exists) {
+        setErrorToast("This service time is already added to the group.");
+        return;
+      }
+
       const gst = { groupId: props.group.id, serviceTimeId: addServiceTimeId } as GroupServiceTimeInterface;
       ApiHelper.post("/groupservicetimes", [gst], "AttendanceApi").then(loadData);
     },
-    [props.group.id, addServiceTimeId, loadData]
+    [props.group.id, addServiceTimeId, loadData, groupServiceTimes]
   );
 
   const handleChange = useCallback((e: SelectChangeEvent) => {
@@ -109,6 +118,9 @@ export const ServiceTimesEdit = memo((props: Props) => {
           {options}
         </Select>
       </FormControl>
+      <Snackbar open={!!errorToast} autoHideDuration={5000} onClose={() => setErrorToast("")} anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
+        <Alert severity="error" onClose={() => setErrorToast("")}>{errorToast}</Alert>
+      </Snackbar>
     </div>
   );
 });

--- a/src/helpers/SecondaryMenuHelper.ts
+++ b/src/helpers/SecondaryMenuHelper.ts
@@ -79,7 +79,8 @@ export class SecondaryMenuHelper {
   static getProfileMenu = (path:string) => {
     const menuItems: MenuItem[] = [];
     let label: string = "";
-    if (path.startsWith("/profile")) label = Locale.label("helpers.secondaryMenuHelper.profile");
+    if (path.startsWith("/profile/devices")) label = Locale.label("helpers.secondaryMenuHelper.devices");
+    else if (path.startsWith("/profile")) label = Locale.label("helpers.secondaryMenuHelper.profile");
     menuItems.push({ url: "/profile", label: Locale.label("helpers.secondaryMenuHelper.profile"), icon: "person" });
     menuItems.push({ url: "/profile/devices", label: Locale.label("helpers.secondaryMenuHelper.devices"), icon: "devices" });
     return { menuItems, label };

--- a/src/profile/components/LinkedAccounts.tsx
+++ b/src/profile/components/LinkedAccounts.tsx
@@ -51,7 +51,7 @@ export const LinkedAccounts = () => {
       <Grid container spacing={3}>
         <Grid size={{ sm: 3 }}>
           <Card>
-            <CardContent sx={{ textAlign: "center" }}>
+            <CardContent sx={{ textAlign: "center", backgroundColor: "#FFF" }}>
               <CardMedia component="img" image="/images/praisecharts.png" alt="Praise Charts" />
               <br />
 


### PR DESCRIPTION
B1Admin
- On the B1admin dark theme profile page, the praiseChart logo readability issue has been resolved, improving its visibility at the UI level.
- On `groups/sAc4gCK3LxQ` → `Edit/Update Group` → `Service Times (Optional)`, there was an issue where, inside the selected service time, the group name was shown multiple times due to the B1admin selection flow. This has now been resolved by adding a selection limitation for service times within a particular group. If a user attempts to add a service time that has already been added, a toast message will be displayed: “Service time already added to this group.
- Fixed a UI bug on the `/profile` page where the active tab wasn't highlighting correctly when switching to the Devices tab.


**Bugs Evidence:-** 
<img width="685" height="285" alt="image" src="https://github.com/user-attachments/assets/6f934e0a-55e6-4495-89b8-2aa96efc7337" />

<img width="1440" height="900" alt="Screenshot 2026-08-27 at 11 52 05 AM" src="https://github.com/user-attachments/assets/f4e12dad-5a3e-4710-9d0d-2f85ac164adb" />

https://github.com/user-attachments/assets/76e279d2-f7d8-41f4-bef5-645569991191

