### PR TITLE
Theme the position category dropdown for dark mode

### DIFF
--- a/src/serving/components/PositionEdit.tsx
+++ b/src/serving/components/PositionEdit.tsx
@@ -20,6 +20,21 @@ type OptionType = {
   label: string;
 };
 
+// react-select renders outside the MUI theme, so it needs the theme css variables directly.
+const selectStyles = {
+  menuPortal: (base: AnyRecord) => ({ ...base, zIndex: 9999 }),
+  menu: (base: AnyRecord) => ({ ...base, zIndex: 9999, backgroundColor: "var(--bg-card)", border: "1px solid var(--border-main)" }),
+  control: (base: AnyRecord) => ({ ...base, backgroundColor: "var(--bg-card)", borderColor: "var(--border-main)" }),
+  singleValue: (base: AnyRecord) => ({ ...base, color: "var(--text-main)" }),
+  input: (base: AnyRecord) => ({ ...base, color: "var(--text-main)" }),
+  placeholder: (base: AnyRecord) => ({ ...base, color: "var(--text-muted)" }),
+  option: (base: AnyRecord, state: { isSelected: boolean; isFocused: boolean }) => ({
+    ...base,
+    backgroundColor: state.isSelected ? "var(--c1)" : state.isFocused ? "var(--bg-sub)" : "transparent",
+    color: state.isSelected ? "#FFFFFF" : "var(--text-main)"
+  })
+};
+
 export const PositionEdit = (props: Props) => {
   const initialOptions: OptionType[] = props.categoryNames.map((n) => ({ value: n, label: n }));
 
@@ -118,7 +133,7 @@ export const PositionEdit = (props: Props) => {
               onBlur={handleCategoryBlur}
               className="comboBox"
               menuPortalTarget={document.body}
-              styles={{ menu: (base) => ({ ...base, zIndex: 9999 }) }}
+              styles={selectStyles}
             />
           )} />
         </FormControl>

--- a/tests/issue-1042.spec.ts
+++ b/tests/issue-1042.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { login } from "./helpers/auth";
+import { STORAGE_STATE_PATH } from "./global-setup";
+
+// Issue #1042: in dark mode the position category dropdown (react-select) keeps its default
+// light menu, so the option text — which inherits the dark theme's near-white body color —
+// renders white on white and the unselected categories are invisible.
+const DEMO_PLAN = "/serving/plans/PLA00000001";
+
+// Contrast ratio between an element's text color and the first opaque background behind it.
+const contrastRatio = (handle: import("@playwright/test").Locator) =>
+  handle.evaluate((el) => {
+    const parse = (value: string): number[] | null => {
+      const match = value.match(/rgba?\(([^)]+)\)/);
+      if (!match) return null;
+      const parts = match[1].split(",").map((p) => parseFloat(p.trim()));
+      return [parts[0], parts[1], parts[2], parts.length > 3 ? parts[3] : 1];
+    };
+    const luminance = (rgb: number[]) => {
+      const channel = (v: number) => {
+        const c = v / 255;
+        return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+      };
+      return 0.2126 * channel(rgb[0]) + 0.7152 * channel(rgb[1]) + 0.0722 * channel(rgb[2]);
+    };
+    const fg = parse(getComputedStyle(el).color);
+    let node: HTMLElement | null = el as HTMLElement;
+    let bg: number[] | null = null;
+    while (node) {
+      const parsed = parse(getComputedStyle(node).backgroundColor);
+      if (parsed && parsed[3] !== 0) { bg = parsed; break; }
+      node = node.parentElement;
+    }
+    if (!fg || !bg) return 0;
+    const l1 = luminance(fg);
+    const l2 = luminance(bg);
+    return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+  });
+
+test.describe("issue-1042 position category dropdown in dark mode", () => {
+  test.describe.configure({ retries: 0 });
+
+  test("unselected category options are readable against the menu background", async ({ browser }) => {
+    const context = await browser.newContext({ storageState: STORAGE_STATE_PATH });
+    await context.addInitScript(() => window.localStorage.setItem("b1admin-theme-mode", "dark"));
+    const page = await context.newPage();
+    try {
+      await login(page);
+      await page.goto(DEMO_PLAN);
+      await expect(page.locator("body.dark-theme")).toHaveCount(1, { timeout: 15000 });
+
+      await page.locator(".positionsTable").getByText("Worship Leader").first().click();
+      await expect(page.locator('[id="name"]')).toHaveValue("Worship Leader", { timeout: 15000 });
+
+      await page.locator(".comboBox").click();
+      const option = page.getByRole("option", { name: "Technical", exact: true });
+      await expect(option).toBeVisible({ timeout: 10000 });
+
+      expect(await contrastRatio(option)).toBeGreaterThan(4.5);
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
The Category Name field on the plan position form is a react-select portalled to the body, so it kept its default white menu while the option text inherited the dark theme's near-white color — unselected categories were invisible. Its styles now come from the app's theme css variables, so both themes read correctly.

https://github.com/ChurchApps/ChurchAppsSupport/issues/1042