### PR TITLE
Serialize people specs that flake in parallel

### DIFF
--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -8,6 +8,7 @@ import { STORAGE_STATE_PATH } from "./global-setup";
 // ZACCHAEUS/ZEBEDEE are test marker names.
 
 test.describe("People Management", () => {
+  test.describe.configure({ mode: "serial" });
 
   test.describe("Individuals", () => {
     test("should view person details", async ({ page }) => {


### PR DESCRIPTION
People household and bulk-group Playwright specs failed under two workers on a shared demo database and passed with one worker. The people suite now runs serially.