### PR TITLE
Fix Sunday-morning console warnings in group, plan, and report UI

### DIFF
--- a/src/components/CampusSelect.tsx
+++ b/src/components/CampusSelect.tsx
@@ -19,12 +19,16 @@ export const CampusSelect: React.FC<Props> = ({ control, name = "campusId", labe
   return (
     <FormControl fullWidth>
       <InputLabel id={labelId}>{lbl}</InputLabel>
-      <Controller name={name} control={control} render={({ field }) => (
-        <Select {...field} value={field.value ?? ""} labelId={labelId} label={lbl} data-testid={testId}>
-          <MenuItem value="">{Locale.label("people.personEdit.noCampus")}</MenuItem>
-          {campuses.map((c) => <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>)}
-        </Select>
-      )} />
+      <Controller name={name} control={control} render={({ field }) => {
+        const raw = field.value ?? "";
+        const known = raw === "" || campuses.some((c) => c.id === raw);
+        return (
+          <Select {...field} value={known ? raw : ""} labelId={labelId} label={lbl} data-testid={testId}>
+            <MenuItem value="">{Locale.label("people.personEdit.noCampus")}</MenuItem>
+            {campuses.map((c) => <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>)}
+          </Select>
+        );
+      }} />
     </FormControl>
   );
 };

--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -56,6 +56,9 @@ export const ComboBox: React.FC<Props> = (props) => {
         onChange={handleSelect}
         data-testid={props.testId ? `${props.testId}-select` : undefined}
         aria-label={props.label}>
+        {props.value && !props.options.includes(props.value) && (
+          <MenuItem key={props.value} value={props.value}>{props.value}</MenuItem>
+        )}
         {props.options.map((option) => (
           <MenuItem key={option} value={option}>{option}</MenuItem>
         ))}

--- a/src/components/reporting/TableReport.tsx
+++ b/src/components/reporting/TableReport.tsx
@@ -25,12 +25,12 @@ export const TableReport = (props: Props) => {
 
   const getRows = () => {
     const result: React.ReactElement[] = [];
-    props.reportResult.table.forEach((d) => {
+    props.reportResult.table.forEach((d, rowIdx) => {
       const row: React.ReactElement[] = [];
-      props.output.columns.forEach((c) => {
-        row.push(<TableCell>{ReportHelper.getField(c, d)}</TableCell>);
+      props.output.columns.forEach((c, colIdx) => {
+        row.push(<TableCell key={c.value || colIdx}>{ReportHelper.getField(c, d)}</TableCell>);
       });
-      result.push(<TableRow>{row}</TableRow>);
+      result.push(<TableRow key={rowIdx}>{row}</TableRow>);
     });
     return result;
   };

--- a/src/components/reporting/TreeReport.tsx
+++ b/src/components/reporting/TreeReport.tsx
@@ -36,31 +36,31 @@ export const TreeReport = (props: Props) => {
     const result: React.ReactElement[] = [];
     const columns = props.output.columns;
     let previousData = {};
-    props.reportResult.table.forEach((d) => {
+    props.reportResult.table.forEach((d, rowIdx) => {
       const row: React.ReactElement[] = [];
-      const groupingRows: React.ReactElement[] = getGroupingRows(previousData, d);
+      const groupingRows: React.ReactElement[] = getGroupingRows(previousData, d, rowIdx);
       groupingRows.forEach((gr) => result.push(gr));
       for (let i = totalGroupings; i < columns.length; i++) {
         const c = columns[i];
-        if (i === totalGroupings) row.push(<TableCell style={{ paddingLeft: 30 * totalGroupings }}>{ReportHelper.getField(c, d)}</TableCell>);
-        else row.push(<TableCell>{ReportHelper.getField(c, d)}</TableCell>);
+        if (i === totalGroupings) row.push(<TableCell key={c.value || i} style={{ paddingLeft: 30 * totalGroupings }}>{ReportHelper.getField(c, d)}</TableCell>);
+        else row.push(<TableCell key={c.value || i}>{ReportHelper.getField(c, d)}</TableCell>);
       }
-      result.push(<TableRow>{row}</TableRow>);
+      result.push(<TableRow key={`row-${rowIdx}`}>{row}</TableRow>);
       previousData = d;
     });
     return result;
   };
 
-  const getGroupingRows = (previousData: any, data: any) => {
+  const getGroupingRows = (previousData: any, data: any, rowIdx: number) => {
     const result: React.ReactElement[] = [];
     const firstGroupModified = getFirstGroupModified(previousData, data);
     for (let i = firstGroupModified; i <= groupings.length; i++) {
-      result.push(getGroupingRow(data, i));
+      result.push(getGroupingRow(data, i, rowIdx));
     }
     return result;
   };
 
-  const getGroupingRow = (row: any, groupNumber: number) => {
+  const getGroupingRow = (row: any, groupNumber: number, rowIdx: number) => {
     const g = groupings[groupNumber];
     const prevCols = getPreviousGroupingCount(groupNumber);
     const outputRow: React.ReactElement[] = [];
@@ -69,13 +69,13 @@ export const TreeReport = (props: Props) => {
       const className = "heading" + (groupNumber + 1);
       if (i === prevCols && i > 0) {
         outputRow.push(
-          <TableCell className={className} style={{ paddingLeft: 30 * groupNumber }}>
+          <TableCell key={c.value || i} className={className} style={{ paddingLeft: 30 * groupNumber }}>
             {ReportHelper.getField(c, row)}
           </TableCell>
         );
-      } else outputRow.push(<TableCell className={className}>{ReportHelper.getField(c, row)}</TableCell>);
+      } else outputRow.push(<TableCell key={c.value || i} className={className}>{ReportHelper.getField(c, row)}</TableCell>);
     }
-    return <TableRow>{outputRow}</TableRow>;
+    return <TableRow key={`group-${rowIdx}-${groupNumber}`}>{outputRow}</TableRow>;
   };
 
   const getFirstGroupModified = (previousRow: any, row: any) => {

--- a/src/components/ui/NavigationTabs.tsx
+++ b/src/components/ui/NavigationTabs.tsx
@@ -78,6 +78,9 @@ export const NavigationTabs = memo((props: Props) => {
     handleDropdownClose();
   };
 
+  const tabValues = tabs.map((t) => t.value).filter(Boolean);
+  const tabsValue = tabValues.includes(selectedTab) ? selectedTab : (tabValues[0] || false);
+
   const handleTabChange = (_event: React.SyntheticEvent, newValue: string) => {
     if (newValue !== dropdown?.value) onTabChange(newValue);
   };
@@ -89,7 +92,7 @@ export const NavigationTabs = memo((props: Props) => {
   return (
     <div style={containerStyle}>
       <Tabs
-        value={selectedTab}
+        value={tabsValue}
         onChange={handleTabChange}
         variant="scrollable"
         scrollButtons="auto"

--- a/src/groups/GroupPage.tsx
+++ b/src/groups/GroupPage.tsx
@@ -15,7 +15,7 @@ import { useQuery } from "@tanstack/react-query";
 export const GroupPage = () => {
   const params = useParams();
 
-  const [selectedTab, setSelectedTab] = React.useState("");
+  const [selectedTab, setSelectedTab] = React.useState("members");
   const [editMode, setEditMode] = React.useState(false);
 
   const group = useQuery<GroupInterface>({

--- a/src/mobile/KioskThemeEdit.tsx
+++ b/src/mobile/KioskThemeEdit.tsx
@@ -138,7 +138,7 @@ export const KioskThemeEdit: React.FC = () => {
 
   if (editingImage === "slide") {
     const currentUrl = editingSlideIndex < config.idleScreen.slides.length ? config.idleScreen.slides[editingSlideIndex]?.imageUrl : "";
-    return <ImageEditor aspectRatio={16 / 9} photoUrl={currentUrl || ""} onCancel={() => setEditingImage(null)} onUpdate={handleSlideImageUpdate} outputWidth={1920} outputHeight={1080} />;
+    return <ImageEditor aspectRatio={16 / 9} photoUrl={currentUrl || "/images/no-image.png"} onCancel={() => setEditingImage(null)} onUpdate={handleSlideImageUpdate} outputWidth={1920} outputHeight={1080} />;
   }
 
   return (

--- a/src/serving/components/PositionList.tsx
+++ b/src/serving/components/PositionList.tsx
@@ -86,6 +86,7 @@ export const PositionList = (props: Props) => {
       const label = remaining === 1 ? Locale.label("plans.positionList.persNeed") : remaining.toString() + Locale.label("plans.positionList.pplNeed");
       result.push(
         <button
+          key="remaining"
           type="button"
           onClick={() => props.onAssignmentSelect?.(position, { positionId: position.id })}
           style={{ background: "none", border: 0, padding: 0, color: "var(--link)", cursor: "pointer" }}>
@@ -101,7 +102,7 @@ export const PositionList = (props: Props) => {
     const hasPeople = assignments.length > 0;
     const group = position.groupId && Array.isArray(props.groups) ? ArrayHelper.getOne(props.groups, "id", position.groupId) : null;
     return (
-      <TableRow style={{ backgroundColor: color }}>
+      <TableRow key={position.id} style={{ backgroundColor: color }}>
         <TableCell style={{ paddingLeft: 10, paddingTop: 10, paddingBottom: 10, fontWeight: "bold", verticalAlign: "top" }}>{first ? position.categoryName : ""}</TableCell>
         <TableCell style={{ paddingTop: 10, paddingBottom: 10, verticalAlign: "top" }}>
           {canEdit ? (

--- a/src/serving/components/TimeList.tsx
+++ b/src/serving/components/TimeList.tsx
@@ -61,7 +61,7 @@ export const TimeList = (props: Props) => {
 
   const getRows = () => {
     const result: JSX.Element[] = [];
-    props.times.forEach((t) => {
+    props.times.forEach((t, i) => {
       const teamList = t.teams?.split(",") || [];
       const startTime = new Date(t.startTime || new Date());
       //startTime.setMinutes(startTime.getMinutes() - startTime.getTimezoneOffset());
@@ -74,7 +74,7 @@ export const TimeList = (props: Props) => {
           ? Locale.label("plans.timeEdit.typeOther")
           : Locale.label("plans.timeEdit.typeService");
       result.push(
-        <tr key={t.id}>
+        <tr key={t.id || `time-${i}`}>
           <td style={{ verticalAlign: "top" }}>
             <Icon>{typeIcon}</Icon>
           </td>
@@ -102,7 +102,7 @@ export const TimeList = (props: Props) => {
     });
     if (props.times.length === 0) {
       result.push(
-        <tr>
+        <tr key="no-times">
           <td colSpan={2}>{Locale.label("plans.timeList.noTime")}</td>
         </tr>
       );
@@ -125,7 +125,7 @@ export const TimeList = (props: Props) => {
   } else {
     return (
       <DisplayBox headerText={Locale.label("plans.timeList.times")} headerIcon="schedule" editContent={getAddTimeLink()}>
-        <table style={{ width: "100%" }}>{getRows()}</table>
+        <table style={{ width: "100%" }}><tbody>{getRows()}</tbody></table>
       </DisplayBox>
     );
   }

--- a/src/serving/songs/components/Keys.tsx
+++ b/src/serving/songs/components/Keys.tsx
@@ -286,7 +286,7 @@ export const Keys = memo((props: Props) => {
           </Stack>
 
           <Box sx={{ borderBottom: 1, borderColor: "divider", mb: 2 }}>
-            <Tabs value={selectedKey?.id || ""} onChange={handleTabChange} variant="scrollable" scrollButtons="auto" aria-label={Locale.label("songs.keys.keysTabsAria")}>
+            <Tabs value={selectedKey?.id || (canEdit ? "add" : false)} onChange={handleTabChange} variant="scrollable" scrollButtons="auto" aria-label={Locale.label("songs.keys.keysTabsAria")}>
               {tabsComponent}
               {canEdit && (
                 <Tab

--- a/src/site/components/AppearanceEdit.tsx
+++ b/src/site/components/AppearanceEdit.tsx
@@ -160,7 +160,7 @@ export function AppearanceEdit(props: Props) {
 
       return (
         <ImageEditor
-          photoUrl={currentUrl || ""}
+          photoUrl={currentUrl || "/images/no-image.png"}
           onUpdate={(dataUrl) => { imageUpdated(dataUrl || "", logoName); }}
           onCancel={() => { setEditLogo(false); setCurrentUrl(null); }}
           aspectRatio={aspectRatio}


### PR DESCRIPTION
MUI Select/Tabs were logging out-of-range values, TimeList rendered table rows without tbody or stable keys, and report tables reused ids as React keys. Clamp missing options, wrap rows in tbody, and key lists by row index.