### PR TITLE
fix: keep save status accurate across page switches and failed saves

### DIFF
--- a/src/site/admin/saveStatusTracker.ts
+++ b/src/site/admin/saveStatusTracker.ts
@@ -5,28 +5,35 @@ export type SaveStatus = "saved" | "saving" | "error";
 let inflight = 0;
 let status: SaveStatus = "saved";
 let lastSavedAt: number | null = null;
+// Bumped on reset so saves still in flight from a previous page can't drive inflight negative.
+let generation = 0;
 const listeners = new Set<() => void>();
 
 const notify = () => listeners.forEach((cb) => cb());
 
 export function trackSave<T>(promise: Promise<T>): Promise<T> {
+  const gen = generation;
   inflight++;
-  if (status !== "saving") { status = "saving"; notify(); }
+  if (status === "saved") { status = "saving"; notify(); }
   return promise.then(
     (result) => {
-      inflight--;
-      if (inflight === 0) {
-        status = "saved";
-        lastSavedAt = Date.now();
-        notify();
-        clearSiteCache();
+      if (gen === generation) {
+        inflight--;
+        if (inflight === 0) {
+          lastSavedAt = Date.now();
+          if (status !== "error") status = "saved";
+          notify();
+          clearSiteCache();
+        }
       }
       return result;
     },
     (error) => {
-      inflight--;
-      status = "error";
-      notify();
+      if (gen === generation) {
+        inflight--;
+        status = "error";
+        notify();
+      }
       throw error;
     }
   );
@@ -41,6 +48,7 @@ export function subscribeSaveStatus(cb: () => void): () => void {
 }
 
 export function resetSaveStatus() {
+  generation++;
   inflight = 0;
   status = "saved";
   lastSavedAt = null;

--- a/tests/save-status-tracker.spec.ts
+++ b/tests/save-status-tracker.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+import { register } from "node:module";
+
+// siteCache.ts pulls in @churchapps/apphelper, which node cannot resolve outside the
+// bundler, so stub it with an ESM loader hook before importing the tracker.
+const hook = `
+  export async function resolve(spec, ctx, next) {
+    if (spec.includes("siteCache")) return { url: "stub:siteCache", shortCircuit: true };
+    return next(spec, ctx);
+  }
+  export async function load(url, ctx, next) {
+    if (url === "stub:siteCache") return {
+      format: "module",
+      shortCircuit: true,
+      source: "export const clearSiteCache = () => { globalThis.__clearSiteCacheCalls++; };"
+    };
+    return next(url, ctx);
+  }
+`;
+register("data:text/javascript," + encodeURIComponent(hook));
+
+const { trackSave, getSaveStatus, getLastSavedAt, resetSaveStatus } = await import("../src/site/admin/saveStatusTracker");
+
+const deferred = <T>() => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+};
+
+const cacheClears = () => (globalThis as any).__clearSiteCacheCalls;
+
+test.beforeEach(() => {
+  (globalThis as any).__clearSiteCacheCalls = 0;
+  resetSaveStatus();
+});
+
+test.describe("saveStatusTracker", () => {
+  test("a save settling after a page switch is ignored and later saves still work", async () => {
+    const stale = deferred<string>();
+    const staleTracked = trackSave(stale.promise);
+
+    resetSaveStatus();
+    stale.resolve("stale");
+    expect(await staleTracked).toBe("stale");
+    expect(getSaveStatus()).toBe("saved");
+    expect(getLastSavedAt()).toBeNull();
+    expect(cacheClears()).toBe(0);
+
+    const next = deferred<string>();
+    const nextTracked = trackSave(next.promise);
+    expect(getSaveStatus()).toBe("saving");
+
+    next.resolve("next");
+    expect(await nextTracked).toBe("next");
+    expect(getSaveStatus()).toBe("saved");
+    expect(getLastSavedAt()).not.toBeNull();
+    expect(cacheClears()).toBe(1);
+  });
+
+  test("a failed save stays visible until the editor resets", async () => {
+    const failed = deferred<string>();
+    const failedTracked = trackSave(failed.promise);
+    failed.reject(new Error("boom"));
+
+    await expect(failedTracked).rejects.toThrow("boom");
+    expect(getSaveStatus()).toBe("error");
+
+    const ok = deferred<string>();
+    const okTracked = trackSave(ok.promise);
+    expect(getSaveStatus()).toBe("error");
+
+    ok.resolve("ok");
+    await okTracked;
+    expect(getSaveStatus()).toBe("error");
+    expect(getLastSavedAt()).not.toBeNull();
+
+    resetSaveStatus();
+    expect(getSaveStatus()).toBe("saved");
+  });
+});


### PR DESCRIPTION
## Summary
- `resetSaveStatus()` now bumps a generation token that `trackSave` captures at call time. A save that settles after the editor switched pages is ignored for status purposes, so `inflight` can no longer go negative and strand the toolbar on "Saving…" — which also suppressed `clearSiteCache()` for every subsequent save. The result/error still reaches the caller.
- A failed save is sticky: the tracker stays in `error` until `resetSaveStatus()`, so "Unable to save. Please try again." stays visible instead of being wiped by the next autosave. `lastSavedAt` still updates on success.
- No `ContentEditor.tsx` / `EditorToolbar.tsx` change; the toolbar already renders the `error` state. Public API unchanged.

## Test plan
- [x] lint on touched files (`yarn eslint src/site/admin/saveStatusTracker.ts tests/save-status-tracker.spec.ts`)
- [x] `npx playwright test issue-948.spec.ts save-status-tracker.spec.ts` vs local demo — 7 passed
