### PR TITLE
fix: commit table row/column counts on blur or Enter

### DIFF
--- a/src/site/admin/elements/TableEdit.tsx
+++ b/src/site/admin/elements/TableEdit.tsx
@@ -17,6 +17,13 @@ export function TableEdit(props: Props) {
   const cols = (contents.length > 0) ? contents[0].length : 0;
   const markdown = props.parsedData.markdown || false;
   const [editCellIdx, setEditCellIdx] = React.useState<number[] | null>(null);
+  const [rowsText, setRowsText] = React.useState(rows.toString());
+  const [colsText, setColsText] = React.useState(cols.toString());
+
+  // Re-sync on the counts, not on props.contents — the parent re-parses answersJSON
+  // every render, so that array's identity changes even while the grid is unchanged.
+  React.useEffect(() => { setRowsText(rows.toString()); }, [rows]);
+  React.useEffect(() => { setColsText(cols.toString()); }, [cols]);
 
   const updateRows = (newRows: number) => {
     const c = [...contents];
@@ -36,11 +43,22 @@ export function TableEdit(props: Props) {
     return c;
   };
 
+  // Resizing on every keystroke would truncate the grid on the intermediate "1" of "12".
+  const commit = (name: "rows" | "columns") => {
+    const isRows = name === "rows";
+    const current = isRows ? rows : cols;
+    const n = Number(isRows ? rowsText : colsText);
+    if (!Number.isInteger(n) || n < 1) {
+      if (isRows) setRowsText(rows.toString()); else setColsText(cols.toString());
+      return;
+    }
+    if (n === current) return;
+    props.onRealtimeChange({ ...props.parsedData, contents: isRows ? updateRows(n) : updateCols(n) });
+  };
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | SelectChangeEvent<string>) => {
     e.preventDefault();
     const data = { ...props.parsedData };
-    if (e.target.name === "rows") data.contents = updateRows(parseInt(e.target.value));
-    if (e.target.name === "columns") data.contents = updateCols(parseInt(e.target.value));
     if (e.target.name === "head") data.head = (e.target.value === "true");
     if (e.target.name === "markdown") data.markdown = (e.target.value === "true");
     if (e.target.name === "size") data.size = e.target.value;
@@ -88,10 +106,10 @@ export function TableEdit(props: Props) {
     <>
       <Grid container columnSpacing={3}>
         <Grid size={{ md: 6, xs: 12 }}>
-          <TextField fullWidth size="small" label={Locale.label("site.tableEdit.rows")} name="rows" value={rows} onChange={handleChange} data-testid="table-rows-input" />
+          <TextField fullWidth size="small" label={Locale.label("site.tableEdit.rows")} name="rows" value={rowsText} onChange={e => setRowsText(e.target.value)} onBlur={() => commit("rows")} onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); commit("rows"); } }} data-testid="table-rows-input" />
         </Grid>
         <Grid size={{ md: 6, xs: 12 }}>
-          <TextField fullWidth size="small" label={Locale.label("site.tableEdit.columns")} name="columns" value={cols} onChange={handleChange} data-testid="table-columns-input" />
+          <TextField fullWidth size="small" label={Locale.label("site.tableEdit.columns")} name="columns" value={colsText} onChange={e => setColsText(e.target.value)} onBlur={() => commit("columns")} onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); commit("columns"); } }} data-testid="table-columns-input" />
         </Grid>
         <Grid size={{ md: 6, xs: 12 }}>
           <FormControl fullWidth size="small">

--- a/tests/website-table.spec.ts
+++ b/tests/website-table.spec.ts
@@ -1,0 +1,91 @@
+import type { Page } from "@playwright/test";
+import { siteTest as test, expect } from "./helpers/test-fixtures";
+import { login } from "./helpers/auth";
+import { navigateToSite } from "./helpers/navigation";
+import { STORAGE_STATE_PATH } from "./global-setup";
+
+// Rows/Columns must only resize the grid once the typed value is committed —
+// typing "12" used to truncate the table to 1 row on the intermediate keystroke.
+// The table element is never saved, so the demo Home page is left untouched.
+test.describe("Website table element", () => {
+  test.describe.configure({ retries: 0 });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: STORAGE_STATE_PATH });
+    page = await context.newPage();
+    await login(page);
+    await navigateToSite(page);
+  });
+
+  test.afterAll(async () => {
+    await page?.context().close();
+  });
+
+  const cellInputs = () => page.locator('[data-testid^="table-cell-"] input');
+  const rowsInput = () => page.locator('[data-testid="table-rows-input"] input');
+  const colsInput = () => page.locator('[data-testid="table-columns-input"] input');
+
+  test("commits row/column counts on blur or Enter, not per keystroke", async () => {
+    // Scope to the Pages table — the Main Navigation sidebar is also a table with a "Home" row.
+    const homeRow = page.locator("tr").filter({ has: page.locator('[data-testid="edit-page-button"]') }).filter({ hasText: "Home" }).first();
+    await expect(homeRow).toBeVisible({ timeout: 15000 });
+    await homeRow.locator('[data-testid="edit-page-button"]').click();
+    await page.locator("button").getByText("Edit Content").click();
+    const addBtn = page.locator('[data-testid="content-editor-add-button"]');
+    await expect(addBtn).toBeVisible({ timeout: 30000 });
+
+    const card = page.locator('[data-testid="draggable-element-table"]');
+    // The apphelper site header renders ~20px taller than its layout spacer, so it
+    // overlays the top of the editor toolbar and swallows the click.
+    await page.addStyleTag({ content: "#site-app-bar { pointer-events: none; }" });
+    if (!await card.isVisible().catch(() => false)) await addBtn.click();
+    await expect(card).toBeVisible({ timeout: 10000 });
+    await card.click();
+
+    // A new table defaults to 4 rows x 2 columns.
+    await expect(rowsInput()).toHaveValue("4", { timeout: 10000 });
+    await expect(cellInputs()).toHaveCount(8);
+    await page.locator('[data-testid="table-cell-3-0-input"] input').fill("keep");
+
+    // Invalid input commits nothing and the field snaps back to the real count.
+    await rowsInput().fill("abc");
+    await rowsInput().press("Tab");
+    await expect(rowsInput()).toHaveValue("4");
+    await expect(cellInputs()).toHaveCount(8);
+    await rowsInput().fill("");
+    await rowsInput().press("Tab");
+    await expect(rowsInput()).toHaveValue("4");
+    await expect(cellInputs()).toHaveCount(8);
+
+    // Typed a keystroke at a time: the intermediate "1" must not truncate the grid.
+    await rowsInput().press("ControlOrMeta+a");
+    await rowsInput().pressSequentially("12");
+    await rowsInput().press("Tab");
+    await expect(cellInputs()).toHaveCount(24);
+    await expect(page.locator('[data-testid="table-cell-3-0-input"] input')).toHaveValue("keep");
+    await expect(page.locator('[data-testid="table-cell-11-1-input"]')).toHaveCount(1);
+
+    // Enter commits too, and shrinking still truncates once committed.
+    await rowsInput().fill("2");
+    await rowsInput().press("Enter");
+    await expect(cellInputs()).toHaveCount(4);
+
+    // Same rules for columns — the intermediate "1" must not drop column 1.
+    await page.locator('[data-testid="table-cell-0-1-input"] input').fill("keep2");
+    await colsInput().press("ControlOrMeta+a");
+    await colsInput().pressSequentially("12");
+    await colsInput().press("Tab");
+    await expect(cellInputs()).toHaveCount(24);
+    await expect(page.locator('[data-testid="table-cell-0-1-input"] input')).toHaveValue("keep2");
+    await expect(page.locator('[data-testid="table-cell-0-11-input"]')).toHaveCount(1);
+    await colsInput().fill("abc");
+    await colsInput().press("Tab");
+    await expect(colsInput()).toHaveValue("12");
+    await expect(cellInputs()).toHaveCount(24);
+    await colsInput().fill("3");
+    await colsInput().press("Enter");
+    await expect(cellInputs()).toHaveCount(6);
+  });
+});


### PR DESCRIPTION
## Summary
- `TableEdit` resized the grid on every keystroke: typing `12` into **Rows** ran `updateRows(1)` on the intermediate digit, permanently truncating rows 2–4 before `12` was ever committed. Same for **Columns**, and `abc`/empty produced `parseInt` → `NaN`.
- Rows/Columns are now bound to local text state. Typing only updates the string; the grid is spliced on **blur** or **Enter** via a `commit()` that requires a positive integer, and otherwise restores the field to the real count.
- The text re-syncs off the row/column counts rather than off `props.parsedData.contents` — the parent re-parses `answersJSON` on every render, so that array's identity is not stable.
- Cell inputs, the head/markdown/size selects and the markdown cell editor are unchanged.

## Test plan
- [x] `yarn eslint src/site/admin/elements/TableEdit.tsx tests/website-table.spec.ts` — clean
- [x] New `tests/website-table.spec.ts` vs local demo (Api :8084 + B1Admin :3101, after `reset-demo`) — passing. Covers: grow to 12 rows typed a keystroke at a time with row 3 content preserved, `abc`/empty rejected with the field snapping back, shrink via Enter, and the same four cases for columns. Verified it fails on the unfixed component (row 3 loses its text).
- [x] `website.spec.ts` full file: 8 failed / 19 passed / 28 did not run — identical to the same run on clean `main`, so no regression from this change.

### Pre-existing failure (not addressed here)
The apphelper site header renders ~20px taller than its 64px `#app-bar-spacer`, so it overlays the top of page content and swallows clicks on `add-page-button` and `content-editor-add-button`. The new spec works around it locally with a `pointer-events: none` style tag on `#site-app-bar`.
