### PR TITLE
Surface the person data export in the page header

### DIFF
--- a/src/people/components/GdprActions.tsx
+++ b/src/people/components/GdprActions.tsx
@@ -2,7 +2,8 @@
 import React, { useState } from "react";
 import { Accordion, AccordionDetails, AccordionSummary, Alert, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Stack, TextField, Typography } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { ApiHelper, Locale } from "@churchapps/apphelper";
+import { ApiHelper, Locale, Permissions, UserHelper } from "@churchapps/apphelper";
+import { downloadPersonData } from "./personDataExport";
 
 interface Props {
   personId: string;
@@ -20,14 +21,7 @@ export const GdprActions: React.FC<Props> = (props) => {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const data = await ApiHelper.get("/gdpr/people/" + props.personId + "/export", "MembershipApi");
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `person-data-${props.personId}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
+      await downloadPersonData(props.personId);
     } finally {
       setExporting(false);
     }
@@ -46,6 +40,8 @@ export const GdprActions: React.FC<Props> = (props) => {
       setAnonymizing(false);
     }
   };
+
+  if (!UserHelper.checkAccess(Permissions.membershipApi.people.edit)) return null;
 
   return (
     <>

--- a/src/people/components/PersonBanner.tsx
+++ b/src/people/components/PersonBanner.tsx
@@ -9,6 +9,7 @@ import {
   Cake as CakeIcon,
   Wc as WcIcon,
   Favorite as FavoriteIcon,
+  Download as DownloadIcon
 } from "@mui/icons-material";
 import { memo, useMemo, useState, useEffect, type ReactNode } from "react";
 import { AppIconButton } from "../../components/ui/AppIconButton";
@@ -16,6 +17,7 @@ import { StatusChip } from "../../components";
 import { SendTextDialog } from "../../groups/components/SendTextDialog";
 import { AddToWorkflowDialog } from "./AddToWorkflowDialog";
 import { formattedPhoneNumber } from "./PersonEdit";
+import { downloadPersonData } from "./personDataExport";
 
 interface Props {
   person: PersonInterface;
@@ -31,6 +33,7 @@ export const PersonBanner = memo((props: Props) => {
   const [showTextDialog, setShowTextDialog] = useState(false);
   const [showWorkflowDialog, setShowWorkflowDialog] = useState(false);
   const [hasTextingProvider, setHasTextingProvider] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
   const canText = useMemo(() => UserHelper.checkAccess(Permissions.messagingApi.texting.send), []);
   const canEdit = useMemo(() => UserHelper.checkAccess(Permissions.membershipApi.people.edit), []);
@@ -131,6 +134,23 @@ export const PersonBanner = memo((props: Props) => {
       )}
       {canEdit && (
         <AppIconButton label={Locale.label("people.personBanner.addToWorkflow")} icon={<WorkflowIcon />} tone="header" data-testid="add-to-workflow-button" onClick={() => setShowWorkflowDialog(true)} />
+      )}
+      {canEdit && (
+        <AppIconButton
+          label={Locale.label("people.gdprActions.exportData")}
+          icon={<DownloadIcon />}
+          tone="header"
+          disabled={exporting}
+          data-testid="export-person-data-button"
+          onClick={async () => {
+            setExporting(true);
+            try {
+              await downloadPersonData(person.id);
+            } finally {
+              setExporting(false);
+            }
+          }}
+        />
       )}
       {showTextDialog && person?.contactInfo?.mobilePhone && (
         <SendTextDialog

--- a/src/people/components/personDataExport.ts
+++ b/src/people/components/personDataExport.ts
@@ -1,0 +1,12 @@
+import { ApiHelper } from "@churchapps/apphelper";
+
+export const downloadPersonData = async (personId: string) => {
+  const data = await ApiHelper.get("/gdpr/people/" + personId + "/export", "MembershipApi");
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `person-data-${personId}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+};

--- a/tests/person-data-export.spec.ts
+++ b/tests/person-data-export.spec.ts
@@ -1,0 +1,25 @@
+import { peopleTest as test, expect } from "./helpers/test-fixtures";
+import { SEED_PEOPLE, openPersonRow } from "./helpers/fixtures";
+
+test.describe("Person data export", () => {
+  test("downloads the full data packet from the person banner", async ({ page }) => {
+    await openPersonRow(page, SEED_PEOPLE.DONALD);
+
+    const exportButton = page.locator('[data-testid="export-person-data-button"]');
+    await expect(exportButton).toBeVisible({ timeout: 10000 });
+
+    const [download, response] = await Promise.all([
+      page.waitForEvent("download", { timeout: 15000 }),
+      page.waitForResponse((r) => r.url().includes("/gdpr/people/") && r.url().includes("/export") && r.status() === 200, { timeout: 15000 }),
+      exportButton.click()
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/^person-data-.+\.json$/);
+
+    const packet = await response.json();
+    expect(packet.exportedAt).toBeTruthy();
+    for (const key of ["person", "groups", "notes", "formSubmissions", "customFieldValues", "tasks", "subscriptions", "eventRsvps"]) {
+      expect(packet).toHaveProperty(key);
+    }
+  });
+});


### PR DESCRIPTION
The export action was buried in a collapsed accordion at the bottom of the edit form, so I put an Export Data button in the person banner next to the other admin actions and shared the download logic between the two. The GDPR panel now also gates on people edit like its sibling components. New Playwright spec covers the button and the download. Pairs with Api#121 — no new locale keys were needed, the button reuses the existing people.gdprActions.exportData label.