### PR TITLE
feat: ccli reject reason and the missing commons review labels

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2876,11 +2876,34 @@
       "reason": "Reason",
       "recentlyResolved": "Recently Resolved",
       "reject": "Reject",
+      "rejectReason": {
+        "quality": "Quality",
+        "duplicate": "Duplicate",
+        "licensing": "Licensing",
+        "ccli": "Copyrighted (CCLI) song",
+        "offtopic": "Off topic",
+        "incomplete": "Incomplete",
+        "other": "Other"
+      },
       "remove": "Remove",
       "removeConfirm": "Remove {name}? It will no longer be available to anyone.",
+      "removeReason": {
+        "copyright": "Copyright",
+        "policy": "Policy"
+      },
       "reporterRole": "Reporter Role",
       "republish": "Republish",
+      "resolution": {
+        "upheld": "Upheld",
+        "dismissed": "Dismissed",
+        "duplicate": "Duplicate"
+      },
       "resolve": "Resolve",
+      "resolveAction": {
+        "none": "No action",
+        "unpublish": "Unpublish",
+        "remove": "Remove"
+      },
       "review": "Review",
       "rights": "Rights",
       "rightsFlag": "Rights",

--- a/src/serverAdmin/commonsApi.ts
+++ b/src/serverAdmin/commonsApi.ts
@@ -19,14 +19,14 @@ export const getWorshipCommonsOrigin = (): string => {
 
 export type AssetStatus = "pending" | "published" | "unpublished" | "removed";
 export type FileAction = "add" | "replace" | "remove";
-export type RejectReason = "quality" | "duplicate" | "licensing" | "offtopic" | "incomplete" | "other";
+export type RejectReason = "quality" | "duplicate" | "licensing" | "ccli" | "offtopic" | "incomplete" | "other";
 export type ReportReason = "copyright" | "policy" | "quality" | "other";
 export type ReportStatus = "open" | "reviewing" | "resolved";
 export type ReportResolution = "upheld" | "dismissed" | "duplicate";
 export type ReportAction = "none" | "unpublish" | "remove";
 export type RemovedReason = "copyright" | "policy";
 
-export const REJECT_REASONS: RejectReason[] = ["quality", "duplicate", "licensing", "offtopic", "incomplete", "other"];
+export const REJECT_REASONS: RejectReason[] = ["quality", "duplicate", "licensing", "ccli", "offtopic", "incomplete", "other"];
 export const RESOLUTIONS: ReportResolution[] = ["upheld", "dismissed", "duplicate"];
 export const RESOLVE_ACTIONS: ReportAction[] = ["none", "unpublish", "remove"];
 export const REMOVE_REASONS: RemovedReason[] = ["copyright", "policy"];

--- a/tests/serverAdmin-commons.spec.ts
+++ b/tests/serverAdmin-commons.spec.ts
@@ -156,6 +156,41 @@ test.describe("serverAdmin Commons tab", () => {
     await expect(assetRow.getByText("Published")).toBeVisible();
   });
 
+  test("quick reject offers the CCLI reason and posts reason=ccli", async ({ page, request }) => {
+    const title = `Spec Song CCLI ${Date.now()}`;
+    const { userJwt } = await apiLogin(request);
+    const sub = await seedSongSubmission(request, userJwt, title, false);
+
+    await login(page);
+    await navigateTo(page, "serverAdmin");
+
+    const commonsSection = page.locator('[data-testid="settings-section-commons"]');
+    await expect(commonsSection).toBeVisible();
+    await commonsSection.click();
+    await expect(page).toHaveURL(/[?&]tab=commons/);
+
+    const row = page.locator(`[data-testid="commons-queue-row-${sub.submissionId}"]`);
+    await expect(row).toBeVisible();
+    await row.getByTestId(`commons-reject-${sub.submissionId}`).click();
+
+    // The reason dropdown must render the translated label, not the raw locale key.
+    await page.getByTestId("commons-reject-reason").click();
+    const ccliOption = page.getByRole("option", { name: "Copyrighted (CCLI) song" });
+    await expect(ccliOption).toBeVisible();
+    await expect(page.getByRole("listbox")).not.toContainText("serverAdmin.commonsTab.rejectReason.ccli");
+    await ccliOption.click();
+
+    await page.getByTestId("commons-reject-note").locator("textarea").first().fill("This song is in the CCLI catalog.");
+
+    const rejectRequest = page.waitForRequest((r) => r.method() === "POST" && r.url().includes(`/commons/admin/submissions/${sub.submissionId}/reject`));
+    await page.getByTestId("commons-reject-confirm").click();
+    await expect(row).not.toBeVisible();
+
+    const posted = (await rejectRequest).postDataJSON();
+    expect(posted.reason).toBe("ccli");
+    expect(String(posted.note || "").trim().length).toBeGreaterThan(0);
+  });
+
   test("opens Commons from tab query param", async ({ page }) => {
     await login(page);
     await page.goto("/admin?tab=commons");


### PR DESCRIPTION
## Summary

Two fixes to the server-admin Commons review UI.

**1. New `ccli` reject reason.** Added to `RejectReason` and `REJECT_REASONS` in `src/serverAdmin/commonsApi.ts`, in the same position as the API's list. It shows in both reject dropdowns (`CommonsTab` quick-reject and `CommonsReviewDrawer`) as **Copyrighted (CCLI) song**.

**2. The reviewer dropdowns were rendering raw locale keys.** `CommonsTab.tsx` and `CommonsReviewDrawer.tsx` ask for `serverAdmin.commonsTab.rejectReason.*`, `.resolution.*`, `.resolveAction.*` and `.removeReason.*`, but none of those nodes existed in `public/locales/en.json` — so a reviewer picking a reject reason, a report resolution, a resolve action or a removal reason saw the key string instead of a label. All four nodes are now present. English only; other locales fall back to English.

## Test plan

```
npx tsc --noEmit     # clean
npx eslint src/serverAdmin/commonsApi.ts src/serverAdmin/components/CommonsTab.tsx src/serverAdmin/components/CommonsReviewDrawer.tsx   # clean
npx eslint src/      # 266 problems (104 errors, 162 warnings) — byte-identical to the same command on main
```

`en.json` re-parses as valid JSON with the four new nodes carrying every enum value used by the components.

No e2e run: this is a locale-data plus enum change with no new behaviour to drive, and the ports for the shared demo stack were in use by another run.

## Cross-repo

Ships with:

- ChurchApps/Api#127 — validator accepts `ccli`, and the writer's rejection email carries the SongSelect link. **Merge that first**, otherwise this dropdown option is rejected with a 400.
- ChurchApps/WorshipCommons#16 — the writer-facing sentence and SongSelect link on /my-songs.

## Migration

None. Purely additive.
