### PR TITLE
chore: bump @churchapps/helpers to 2.3.0 and @churchapps/apphelper to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "packageManager": "yarn@4.15.0",
   "dependencies": {
-    "@churchapps/apphelper": "^1.3.6",
+    "@churchapps/apphelper": "^1.5.0",
     "@churchapps/content-providers": "^0.9.4",
-    "@churchapps/helpers": "^2.2.2",
+    "@churchapps/helpers": "^2.3.0",
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
     "@mui/x-date-pickers": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,9 +376,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@churchapps/apphelper@npm:^1.3.6":
-  version: 1.3.6
-  resolution: "@churchapps/apphelper@npm:1.3.6"
+"@churchapps/apphelper@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@churchapps/apphelper@npm:1.5.0"
   dependencies:
     "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.14.0"
@@ -440,7 +440,7 @@ __metadata:
       optional: true
     react-google-recaptcha:
       optional: true
-  checksum: 10c0/47c82a165acf744cc08add5cb9dcc2497dc93fdd8998c85659fb2405f01f25a908d3e1799980440ec14964059d726e4020f73b59fa494fa38b4f99928482cd33
+  checksum: 10c0/860f91c30233031ade2df30224be2fa9c1ce6cb4cf2f4c2baf02308bd5ab9ec502a1b5dc1122f7d99af2fcc453fc75836307c78b47770da65cbc78368c521cd4
   languageName: node
   linkType: hard
 
@@ -451,9 +451,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@churchapps/helpers@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@churchapps/helpers@npm:2.2.2"
+"@churchapps/helpers@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@churchapps/helpers@npm:2.3.0"
   dependencies:
     dayjs: "npm:^1.11.20"
   peerDependencies:
@@ -461,7 +461,7 @@ __metadata:
   peerDependenciesMeta:
     rrule:
       optional: true
-  checksum: 10c0/47fe3071cddffd365d5dbe23c7dcdb56048dbc0760fbcb25bb247bddb1fb6de491cb1f91c70f90f75af6585e8a26d3b037b3fb9faf35d3bf2e54ef900fd6045f
+  checksum: 10c0/b8f049cb27e541ce4958b53fa1cf532f416cc44e106262b94e3adb5df4fbb30a8b3030aa61906906c1d82f1a73cf99eb40692c9c63a771eafbb11ff0c33b716c
   languageName: node
   linkType: hard
 
@@ -2897,9 +2897,9 @@ __metadata:
   resolution: "b1admin@workspace:."
   dependencies:
     "@babel/core": "npm:^8.0.1"
-    "@churchapps/apphelper": "npm:^1.3.6"
+    "@churchapps/apphelper": "npm:^1.5.0"
     "@churchapps/content-providers": "npm:^0.9.4"
-    "@churchapps/helpers": "npm:^2.2.2"
+    "@churchapps/helpers": "npm:^2.3.0"
     "@eslint/js": "npm:^10.0.1"
     "@mui/icons-material": "npm:^7.3.11"
     "@mui/material": "npm:^7.3.11"


### PR DESCRIPTION
## Summary
Bump `@churchapps/helpers` from 2.2.2 to 2.3.0 and `@churchapps/apphelper` from 1.3.6 to 1.5.0 so B1Admin picks up the published packages. Lockfile was pinned at helpers 2.2.2 (song upload allowlist WC/PD only); 2.3.0 adds CC-BY.

## Test plan
- [x] `yarn tsc --noEmit` in the worktree (clean)
- [ ] Smoke B1Admin start against the updated packages

## Cross-repo
Pairs with Api helpers 2.3.0 bump for WorshipCommons CC-BY uploads (https://github.com/ChurchApps/Api/pull/138).