### PR TITLE
Playwright hosts from env for demo slots

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const STORAGE_STATE_PATH = path.join(__dirname, "tests", ".auth-state.json");
 
 const baseURL = process.env.BASE_URL || "http://localhost:3101";
+const apiBase = process.env.API_BASE || "http://localhost:8084";
+const messagingSocket = process.env.REACT_APP_MESSAGING_API_SOCKET || "ws://localhost:8087";
 
 export default defineConfig({
   testDir: "./tests",
@@ -36,7 +38,7 @@ export default defineConfig({
   webServer: [
     {
       command: "npm --prefix ../Api run dev",
-      url: "http://localhost:8084/health",
+      url: `${apiBase}/health`,
       reuseExistingServer: true,
       timeout: 60 * 1000,
       stdout: "pipe",
@@ -46,10 +48,12 @@ export default defineConfig({
       command: "npm start",
       // Force dev stage to use localhost URLs; messaging socket to local Api's WS.
       env: {
+        PORT: new URL(baseURL).port || "3101",
         REACT_APP_STAGE: "dev",
-        REACT_APP_MESSAGING_API_SOCKET: "ws://localhost:8087"
+        REACT_APP_API_BASE: apiBase,
+        REACT_APP_MESSAGING_API_SOCKET: messagingSocket
       },
-      url: "http://localhost:3101",
+      url: baseURL,
       reuseExistingServer: true,
       timeout: 120 * 1000
     }

--- a/tests/audit-log.spec.ts
+++ b/tests/audit-log.spec.ts
@@ -4,7 +4,7 @@ import { openKnownPerson, personDetailsEditButton, SEED_PEOPLE } from "./helpers
 
 // Universal audit log + undoable batches. The batch/undo scenarios drive the Api directly
 // (Playwright request context) and verify the outcome through the B1Admin Settings pages.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 
 async function apiLogin(ctx: APIRequestContext): Promise<string> {
   const res = await ctx.post(`${API}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });

--- a/tests/checkin-safety.spec.ts
+++ b/tests/checkin-safety.spec.ts
@@ -9,7 +9,7 @@ import { STORAGE_STATE_PATH } from "./global-setup";
 // throwaway person so it never mutates the kiosk agent's seeded rows
 // (GRP00000009, Smith household HOU00000001).
 
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const TS = Date.now();
 
 let api: APIRequestContext;

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -512,7 +512,7 @@ test.describe("QuickBooks export", () => {
 // Notes column: seed the batch directly via API (the BatchEdit date field is a
 // known-broken MUI date section input under Playwright, unrelated to this feature)
 // so the UI portion only exercises what's actually under test — bulk entry + list display.
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const NOTES_BATCH_NAME = "Habakkuk Notes Batch";
 const NOTES_TEXT = "Envelope #42 — pledge campaign gift";
 

--- a/tests/event-permissions.spec.ts
+++ b/tests/event-permissions.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, request } from "@playwright/test";
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 
 test.describe.serial("Event permission gate (POST /content/events)", () => {
   let ctx: Awaited<ReturnType<typeof request.newContext>>;

--- a/tests/event-reminders.spec.ts
+++ b/tests/event-reminders.spec.ts
@@ -5,7 +5,7 @@ import { login } from "./helpers/auth";
 import { STORAGE_STATE_PATH } from "./global-setup";
 import { dismissSendInviteIfPresent, confirmDelete } from "./helpers/fixtures";
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 const CALENDAR = "Zacchaeus Reminder Calendar";
 const EVENT_TITLE = "Zacchaeus Reminder Event";

--- a/tests/failed-recurring-gifts.spec.ts
+++ b/tests/failed-recurring-gifts.spec.ts
@@ -3,7 +3,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 
 // Failed recurring gifts dashboard. The failed donation is seeded through the Api (the gateway
 // webhook that normally creates it can't be fired locally) and verified through B1Admin.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const DONOR_ID = "PER00000080"; // Donald Clark
 const DONOR_NAME = "Donald Clark";
 

--- a/tests/form-group-auto-add.spec.ts
+++ b/tests/form-group-auto-add.spec.ts
@@ -6,7 +6,7 @@ import { navigateToPeople } from "./helpers/navigation";
 
 // Camp-registration flow (#1026): a stand-alone form that creates a person record
 // and drops that person straight onto a group's roster.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const FORM_NAME = "Zacchaeus Camp Registration";
 const GROUP_NAME = "Vacation Bible School";
 const CAMPER_EMAIL = "zacchaeus.camper@example.com";

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -10,14 +10,14 @@ async function globalSetup(config: FullConfig) {
   await verifyEnv({ fullCheck: true });
 
   const ctx = await request.newContext();
-  const loginRes = await ctx.post("http://localhost:8084/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
+  const loginRes = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
   if (loginRes.ok()) {
     const loginBody = await loginRes.json();
     const uc = (loginBody.userChurches || []).find((c: any) => c.church?.id === "CHU00000001") || loginBody.userChurches?.[0];
     const auth = { headers: { Authorization: "Bearer " + uc?.jwt } };
-    const groups = await (await ctx.get("http://localhost:8084/membership/groups", auth)).json();
+    const groups = await (await ctx.get((process.env.API_BASE || "http://localhost:8084") + "/membership/groups", auth)).json();
     const stale = (Array.isArray(groups) ? groups : []).filter((g: any) => /^(Bulk All|Zz Bulk) \d+$/.test(g.name || ""));
-    for (const g of stale) await ctx.delete(`http://localhost:8084/membership/groups/${g.id}`, auth);
+    for (const g of stale) await ctx.delete(`${process.env.API_BASE || "http://localhost:8084"}/membership/groups/${g.id}`, auth);
   }
   await ctx.dispose();
 

--- a/tests/group-rsvp.spec.ts
+++ b/tests/group-rsvp.spec.ts
@@ -7,7 +7,7 @@ import { login } from "./helpers/auth";
 // joins. Group membership is JWT-baked at login, so the group + membership are set
 // up BEFORE the browser logs in (a fresh context, not the cached storage state).
 
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const CHURCH_ID = "CHU00000001";
 
 interface Setup {

--- a/tests/issue-1051.spec.ts
+++ b/tests/issue-1051.spec.ts
@@ -6,7 +6,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 // *then* appends "...", so real labels reach 103 chars, overflowing planItems.label varchar(100)
 // under MySQL strict mode. The provider is mocked at the API proxy, as in issue-996-collapse,
 // since no content provider is linked in the local stack.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 
 // 103 chars — exactly what LessonsChurchConverters.truncateForLabel emits for a long "note"
 // action (100 characters of stripped content plus the ellipsis).

--- a/tests/issue-961.spec.ts
+++ b/tests/issue-961.spec.ts
@@ -3,7 +3,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 
 // Issue #961: an arrangement key with no key signature rendered as "Default ()"
 // in the song picker chip and in the saved plan item description.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 
 const SEARCH_RESULTS = [
   {

--- a/tests/issue-988.spec.ts
+++ b/tests/issue-988.spec.ts
@@ -3,7 +3,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 
 // Issue #988: order-of-service items can reference one of the plan's positions so the
 // assigned volunteer's name shows beside the item on screen and in the printout.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const PERSON_ID = "PER00000001";
 const PERSON_NAME = "John Smith";
 

--- a/tests/issue-996-collapse.spec.ts
+++ b/tests/issue-996-collapse.spec.ts
@@ -4,7 +4,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 // Issue #996 (fix 2): "Expand to Actions" permanently rewrote the plan with no way back.
 // The plan is seeded through DoingApi and the provider is mocked at the API proxy, since
 // no content provider is linked in the local stack.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 
 const INSTRUCTIONS = {
   name: "Collapse Repro Lesson",

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -820,13 +820,13 @@ test.describe("People Management", () => {
       await expect(removeDialog).toHaveCount(0, { timeout: 20000 });
 
       const ctx = await request.newContext();
-      const loginRes = await ctx.post("http://localhost:8084/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
+      const loginRes = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
       const loginBody = await loginRes.json();
       const uc = (loginBody.userChurches || []).find((c: any) => c.church?.id === "CHU00000001") || loginBody.userChurches?.[0];
       const auth = { headers: { Authorization: "Bearer " + uc?.jwt } };
-      const allGroups = await (await ctx.get("http://localhost:8084/membership/groups", auth)).json();
+      const allGroups = await (await ctx.get((process.env.API_BASE || "http://localhost:8084") + "/membership/groups", auth)).json();
       const leaked = (Array.isArray(allGroups) ? allGroups : []).find((g: any) => g.name === groupName);
-      if (leaked?.id) await ctx.delete(`http://localhost:8084/membership/groups/${leaked.id}`, auth);
+      if (leaked?.id) await ctx.delete(`${process.env.API_BASE || "http://localhost:8084"}/membership/groups/${leaked.id}`, auth);
       await ctx.dispose();
     });
   });

--- a/tests/registration-commerce.spec.ts
+++ b/tests/registration-commerce.spec.ts
@@ -18,7 +18,7 @@ import { confirmDelete } from "./helpers/fixtures";
 // reset-demo. Event A (built through the UI) drives the settings round-trip + waitlist toggle;
 // Event B (built via the API with a tight capacity) drives the roster/paid/waitlist/CSV assertions.
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CALENDAR = "Zacchaeus Commerce Calendar";
 const EVENT_A = "Zacchaeus Commerce Settings Event";
 const EVENT_B = "Zacchaeus Commerce Roster Event";

--- a/tests/registrations.spec.ts
+++ b/tests/registrations.spec.ts
@@ -7,7 +7,7 @@ import { STORAGE_STATE_PATH } from "./global-setup";
 import { confirmDelete } from "./helpers/fixtures";
 
 
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const CALENDAR = "Zacchaeus Registrations Calendar";
 const EVENT_TITLE = "Zacchaeus Registration Test Event";
 const GROUP = "Middle School Youth";

--- a/tests/serverAdmin-commons.spec.ts
+++ b/tests/serverAdmin-commons.spec.ts
@@ -7,7 +7,7 @@ import { navigateTo } from "./helpers/navigation";
 // which holds a MembershipApi/Domain/Admin rolePermission (RPM00000001). The server expands that
 // into every permission — including Server/Admin — via replaceDomainAdminPermissions/addAllPermissions
 // (Api/src/modules/membership/helpers/UserHelper.ts), so the demo user does have access to this tab.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 
 const auth = (jwt: string) => ({ headers: { Authorization: "Bearer " + jwt } });
 

--- a/tests/serving-event-triggers.spec.ts
+++ b/tests/serving-event-triggers.spec.ts
@@ -7,7 +7,7 @@ import { recoverFromViteError } from "./helpers/fixtures";
 import { STORAGE_STATE_PATH } from "./global-setup";
 
 // Event-driven workflow triggers fire on back-end mutations via WebhookDispatcher.
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 
 // Open the triggers manager for the seeded workflow's board.
 async function openManager(page: Page) {

--- a/tests/serving-plans.spec.ts
+++ b/tests/serving-plans.spec.ts
@@ -498,18 +498,18 @@ test.describe("Plan type row links to the schedule matrix overview", () => {
 
   test.beforeAll(async () => {
     ctx = await pwRequest.newContext();
-    const loginRes = await ctx.post("http://localhost:8084/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
+    const loginRes = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/membership/users/login", { data: { email: "demo@b1.church", password: "password" } });
     expect(loginRes.ok()).toBeTruthy();
     const body = await loginRes.json();
     const uc = (body.userChurches || []).find((c: any) => c.church?.id === "CHU00000001") || body.userChurches?.[0];
     auth = { headers: { Authorization: "Bearer " + uc.jwt } };
-    const typeRes = await ctx.post("http://localhost:8084/doing/planTypes", { ...auth, data: [{ ministryId: WORSHIP_MINISTRY_ID, name: PLAN_TYPE_NAME }] });
+    const typeRes = await ctx.post((process.env.API_BASE || "http://localhost:8084") + "/doing/planTypes", { ...auth, data: [{ ministryId: WORSHIP_MINISTRY_ID, name: PLAN_TYPE_NAME }] });
     expect(typeRes.ok()).toBeTruthy();
     planTypeId = (await typeRes.json())[0].id;
   });
 
   test.afterAll(async () => {
-    if (planTypeId) await ctx.delete(`http://localhost:8084/doing/planTypes/${planTypeId}`, auth);
+    if (planTypeId) await ctx.delete(`${process.env.API_BASE || "http://localhost:8084"}/doing/planTypes/${planTypeId}`, auth);
     await ctx.dispose();
   });
 
@@ -611,7 +611,7 @@ test.describe.serial("Plan pickers honor First Day of Week", () => {
 test.describe.serial("Service Order bulk delete inside a section", () => {
   test.describe.configure({ retries: 0 });
 
-  const API = "http://localhost:8084";
+  const API = process.env.API_BASE || "http://localhost:8084";
   let ctx: APIRequestContext;
   let jwt: string;
   let planId: string;
@@ -719,7 +719,7 @@ test.describe.serial("Service Order bulk delete inside a section", () => {
 test.describe.serial("Service Order multi-select import from the External Item picker", () => {
   test.describe.configure({ retries: 0 });
 
-  const API = "http://localhost:8084";
+  const API = process.env.API_BASE || "http://localhost:8084";
   let ctx: APIRequestContext;
   let jwt: string;
   let planId: string;

--- a/tests/serving-print-plan.spec.ts
+++ b/tests/serving-print-plan.spec.ts
@@ -5,7 +5,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 // sections/actions must not print; kept sections print as-is). LessonsApi isn't
 // in the local stack, so the venue feed is mocked via route interception and the
 // plan is seeded through DoingApi.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 
 const VENUE_FEED = {
   id: "PRINTVENUE1",

--- a/tests/serving-reminders.spec.ts
+++ b/tests/serving-reminders.spec.ts
@@ -7,7 +7,7 @@ import { STORAGE_STATE_PATH } from "./global-setup";
 
 // Use scope-level reminders (API: /messaging/reminders/scope/plan/{planTypeId})
 // rather than plan-type columns; editor needs plan type to have an id.
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 const WORSHIP_MINISTRY_ID = "GRP0000000a";
 // Use a new plan type to avoid offset assertion races with other specs.
 const PLAN_TYPE_NAME = "Zephaniah Reminder Plans";

--- a/tests/serving-signage-feed.spec.ts
+++ b/tests/serving-signage-feed.spec.ts
@@ -3,7 +3,7 @@ import { loggedInTest as test, expect } from "./helpers/test-fixtures";
 
 // Digital signage feed: a plan type acts like a lessons.church classroom — the feed url
 // resolves the current plan and emits the SignPresenter external-playlist format.
-const API = "http://localhost:8084";
+const API = process.env.API_BASE || "http://localhost:8084";
 const WORSHIP_MINISTRY_ID = "GRP0000000a";
 // Venue/section on api.lessons.church that the demo data also uses; its "play" actions carry files.
 const VENUE_ID = "keYYf8Z8ZD1";

--- a/tests/serving-workflows.spec.ts
+++ b/tests/serving-workflows.spec.ts
@@ -253,7 +253,7 @@ test.describe.serial("Serving Management - Workflows", () => {
   });
 
   test("permission tiers are enforced at the API (view / edit-assigned / admin)", async () => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const ctx = await request.newContext();
     // Log in as the seeded "Workflow Volunteer" — DoingApi/Tasks/View only, person PER00000069.
     const loginRes = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "volunteer@b1.church", password: "password" } });
@@ -325,7 +325,7 @@ test.describe.serial("Serving Management - Workflows", () => {
   });
 
   test("a cross-workflow outcome hands the card off to another workflow (API)", async () => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const ctx = await request.newContext();
     const loginRes = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     expect(loginRes.ok()).toBeTruthy();
@@ -351,7 +351,7 @@ test.describe.serial("Serving Management - Workflows", () => {
   });
 
   test("cards stay out of plain-task surfaces and the generic save endpoint (API)", async () => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const ctx = await request.newContext();
     const loginRes = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     expect(loginRes.ok()).toBeTruthy();
@@ -374,7 +374,7 @@ test.describe.serial("Serving Management - Workflows", () => {
   });
 
   test("a manual send-back does not re-trigger the target step onEnter route (API)", async () => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const ctx = await request.newContext();
     const loginRes = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     expect(loginRes.ok()).toBeTruthy();
@@ -397,7 +397,7 @@ test.describe.serial("Serving Management - Workflows", () => {
   });
 
   test("a personMatch route auto-advances a matching card on entry (API)", async () => {
-    const API_BASE = "http://localhost:8084";
+    const API_BASE = process.env.API_BASE || "http://localhost:8084";
     const ctx = await request.newContext();
     const loginRes = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     expect(loginRes.ok()).toBeTruthy();
@@ -418,7 +418,7 @@ test.describe.serial("Serving Management - Workflows", () => {
     await ctx.dispose();
   });
 
-  const API_BASE = "http://localhost:8084";
+  const API_BASE = process.env.API_BASE || "http://localhost:8084";
   async function apiAuth(ctx: any) {
     const loginRes = await ctx.post(`${API_BASE}/membership/users/login`, { data: { email: "demo@b1.church", password: "password" } });
     expect(loginRes.ok()).toBeTruthy();

--- a/tests/setup/verify-env.mjs
+++ b/tests/setup/verify-env.mjs
@@ -1,5 +1,5 @@
 const DEFAULT_BASE_URL = "http://localhost:3101";
-const API_BASE = "http://localhost:8084";
+const API_BASE = process.env.API_BASE || "http://localhost:8084";
 // Tests work against either ENVIRONMENT=demo (stage demo deployments) or
 // ENVIRONMENT=dev pointed at localhost — same set reset-demo accepts.
 const ALLOWED_ENVIRONMENTS = ["demo", "dev"];
@@ -37,7 +37,7 @@ function checkBaseUrl() {
   if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
     refuse([
       `BASE_URL "${raw}" is not local.`,
-      "Tests only run against http://localhost:3101. Unset BASE_URL or point it at localhost.",
+      "Tests only run against a localhost BASE_URL (default http://localhost:3101).",
     ]);
   }
 }

--- a/tests/sites.spec.ts
+++ b/tests/sites.spec.ts
@@ -6,7 +6,7 @@ import { navigateToSite } from "./helpers/navigation";
 import { STORAGE_STATE_PATH } from "./global-setup";
 import { confirmDelete } from "./helpers/fixtures";
 
-const MEMBERSHIP = "http://localhost:8084/membership";
+const MEMBERSHIP = (process.env.API_BASE || "http://localhost:8084") + "/membership";
 const SITE_NAME = "Youth";
 const SITE_SUBDOMAIN = "youthtest";
 


### PR DESCRIPTION
Specs and playwright.config now read BASE_URL, API_BASE and LESSONS_API_BASE (defaults unchanged), so a worktree lane can run its whole stack on shifted ports and its own s<N>_ databases alongside another lane instead of waiting on the single demo lock.